### PR TITLE
ENH: add logic for binary ufuncs

### DIFF
--- a/sparse/core.py
+++ b/sparse/core.py
@@ -403,12 +403,6 @@ class COO(object):
         unmatched_other = np.ones(len(other.data), dtype=bool)
         unmatched_other[matched_other] = False
 
-        print(self.coords.shape, self.data.shape)
-        print(matched_self, unmatched_self)
-        print('----------')
-        print(other.coords.shape, other.data.shape)
-        print(matched_other, unmatched_other)
-
         coords = np.hstack([self.coords[:, matched_self],
                             self.coords[:, unmatched_self],
                             other.coords[:, unmatched_other]])

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -155,9 +155,10 @@ def test_elemwise(func):
 
 
 @pytest.mark.parametrize('func', [operator.mul])
-def test_elemwise_binary(func):
-    x = random_x((2, 3, 4))
-    y = random_x((2, 3, 4))
+@pytest.mark.parametrize('shape', [(2,), (2, 3), (2, 3, 4), (2, 3, 4, 5)])
+def test_elemwise_binary(func, shape):
+    x = random_x(shape)
+    y = random_x(shape)
 
     xs = COO.from_numpy(x)
     ys = COO.from_numpy(y)

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -1,6 +1,7 @@
 import pytest
 
 import random
+import operator
 import numpy as np
 import scipy.sparse
 from sparse import COO
@@ -151,6 +152,17 @@ def test_elemwise(func):
     assert isinstance(func(s), COO)
 
     assert_eq(func(x), func(s))
+
+
+@pytest.mark.parametrize('func', [operator.mul])
+def test_elemwise_binary(func):
+    x = random_x((2, 3, 4))
+    y = random_x((2, 3, 4))
+
+    xs = COO.from_numpy(x)
+    ys = COO.from_numpy(y)
+
+    assert_eq(func(xs, ys), func(x, y))
 
 
 def test_gt():


### PR DESCRIPTION
This adds the ``elemwise_binary`` method that implements an efficient version of the logic needed to perform binary ufuncs where both operators are ``COO`` matrices (as long as ``func(0, 0)=0``).

Currently I only enabled ``__mul__`` and ``__rmul__``, but it should be straightforward to add more.

First commits use a KD Tree approach; the final commit changes this to a binary search within the lex-sorted coordinate array, which should be much faster.