### PR TITLE
Add @ operator (simplify)

### DIFF
--- a/sparse/core.py
+++ b/sparse/core.py
@@ -802,6 +802,10 @@ def tensordot(a, b, axes=2):
 
 
 def dot(a, b):
+    if not hasattr(a, 'ndim') or not hasattr(b, 'ndim'):
+        raise NotImplementedError(
+                "Cannot perform dot product on types %s, %s" %
+                (type(a), type(b)))
     return tensordot(a, b, axes=((a.ndim - 1,), (b.ndim - 2,)))
 
 

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -395,21 +395,6 @@ class COO(object):
             strides *= d
         return out
 
-    def __matmul__(self, other):
-        try:
-            return dot(self, other)
-        except NotImplementedError:
-            return NotImplemented
-
-    def __rmatmul__(self, other):
-        try:
-            return dot(other, self)
-        except NotImplementedError:
-            return NotImplemented
-
-    def __numpy_ufunc__(self, ufunc, method, i, inputs, **kwargs):
-        return NotImplemented
-
     def reshape(self, shape):
         if self.shape == shape:
             return self

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -395,6 +395,21 @@ class COO(object):
             strides *= d
         return out
 
+    def __matmul__(self, other):
+        try:
+            return dot(self, other)
+        except NotImplementedError:
+            return NotImplemented
+
+    def __rmatmul__(self, other):
+        try:
+            return dot(other, self)
+        except NotImplementedError:
+            return NotImplemented
+
+    def __numpy_ufunc__(self, ufunc, method, i, inputs, **kwargs):
+        return NotImplemented
+
     def reshape(self, shape):
         if self.shape == shape:
             return self

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -127,14 +127,68 @@ def test_tensordot(a_shape, b_shape, axes):
 
 
 def test_dot():
+    import operator
     a = random_x((3, 4, 5))
     b = random_x((5, 6))
+    lol = [[1, 2, 3, 4, 5]]
 
     sa = COO.from_numpy(a)
     sb = COO.from_numpy(b)
 
     assert_eq(a.dot(b), sa.dot(sb))
     assert_eq(np.dot(a, b), sparse.dot(sa, sb))
+
+    if hasattr(operator, 'matmul'):
+        # Basic equivalences
+        assert_eq(eval("a @ b"), eval("sa @ sb"))
+        assert_eq(eval("sa @ sb"), sparse.dot(sa, sb))
+        assert_eq(eval("lol @ b"), eval("lol @ sb"))
+
+        # Test that SOO's and np.array's combine correctly
+        assert_eq(eval("a @ sb"), eval("sa @ b"))
+
+
+@pytest.mark.xfail
+def test_dot_nocoercion():
+    a = random_x((3, 4, 5))
+    b = random_x((5, 6))
+
+    la = a.tolist()
+    lb = b.tolist()
+    la, lb          # silencing flake8
+
+    sa = COO.from_numpy(a)
+    sb = COO.from_numpy(b)
+    sa, sb          # silencing flake8
+
+    if sys.version_info >= (3, 5):
+        # Operations with naive collection (list)
+        assert_eq(eval("la @ b"), eval("la @ sb"))
+        assert_eq(eval("a @ lb"), eval("sa @ lb"))
+
+        # Test that SOO's and np.array's combine correctly
+        assert_eq(eval("a @ sb"), eval("sa @ b"))
+
+
+@pytest.mark.xfail
+def test_dot_nocoercion():
+    # Expect failure with non-array naive type (e.g. list)
+    import operator
+    a = random_x((3, 4, 5))
+    b = random_x((5, 6))
+
+    la = a.tolist()
+    lb = b.tolist()
+    la, lb          # silencing flake8
+
+    sa = COO.from_numpy(a)
+    sb = COO.from_numpy(b)
+    sa, sb          # silencing flake8
+
+    if hasattr(operator, 'matmul'):
+        # Operations with naive collection (list)
+        assert_eq(eval("la @ b"), eval("la @ sb"))
+        assert_eq(eval("a @ lb"), eval("sa @ lb"))
 
 
 @pytest.mark.parametrize('func', [np.expm1, np.log1p, np.sin, np.tan,


### PR DESCRIPTION
This supersedes the closed https://github.com/mrocklin/sparse/pull/14.

This request simply adds the `__matmul__` and `__rmatmul__` with no behavior other than that delegated to `sparse.dot()`.  Checks for "correct" non-combination of lists with COOs remains.  A more specific `return NotImplemented` is returned for things lacking an `.ndim`, which gives us a better error of:

```python
TypeError: unsupported operand type(s) for @: 'list' and 'COO'
```