### PR TITLE
Matmul/generic

### DIFF
--- a/sparse/core.py
+++ b/sparse/core.py
@@ -328,6 +328,11 @@ class COO(object):
     def dot(self, other):
         return dot(self, other)
 
+    __matmul__ = dot
+
+    def __rmatmul__(self, other):
+        return dot(other, self)
+
     def reshape(self, shape):
         if self.shape == shape:
             return self

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -326,13 +326,12 @@ class COO(object):
         return self.transpose(list(range(self.ndim))[::-1])
 
     def dot(self, other):
-        return dot(self, other)
-
-    def __matmul__(self, other):
         try:
             return dot(self, other)
-        except AttributeError:
+        except AttributeError:  # missing .ndim
             return dot(self, np.array(other))
+
+    __matmul__ = dot
 
     def __rmatmul__(self, other):
         return dot(np.array(other), self)

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -695,7 +695,7 @@ def dot(a, b, make_array=True):
             a = np.array(a)
         if not hasattr(b, 'ndim'):
             b = np.array(b)
-    return tensordot(a, b, axes=((a.ndim - 1,), (b.ndim - 2,)))
+    return tensordot(a, b, axes=((a.ndim-1,), (b.ndim-2,)))
 
 
 def _dot(a, b):

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -89,7 +89,10 @@ class COO(object):
     """
     __array_priority__ = 12
 
-    def __init__(self, coords, data=None, shape=None, has_duplicates=True):
+    def __init__(self, coords, data=None, shape=None,
+                 has_duplicates=True, toarray_other=False):
+
+        self._toarray_other = toarray_other
         if data is None:
             # {(i, j, k): x, (i, j, k): y, ...}
             if isinstance(coords, dict):
@@ -325,16 +328,14 @@ class COO(object):
     def T(self):
         return self.transpose(list(range(self.ndim))[::-1])
 
-    def dot(self, other):
-        try:
-            return dot(self, other)
-        except AttributeError:  # missing .ndim
-            return dot(self, np.array(other))
+    def dot(self, other, make_array=False):
+        return dot(self, other,
+                   make_array=make_array or self._toarray_other)
 
     __matmul__ = dot
 
     def __rmatmul__(self, other):
-        return dot(np.array(other), self)
+        return dot(other, self)
 
     def reshape(self, shape):
         if self.shape == shape:
@@ -688,7 +689,12 @@ def tensordot(a, b, axes=2):
     return res.reshape(olda + oldb)
 
 
-def dot(a, b):
+def dot(a, b, make_array=True):
+    if make_array:
+        if not hasattr(a, 'ndim'):
+            a = np.array(a)
+        if not hasattr(b, 'ndim'):
+            b = np.array(b)
     return tensordot(a, b, axes=((a.ndim - 1,), (b.ndim - 2,)))
 
 

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -328,7 +328,11 @@ class COO(object):
     def dot(self, other):
         return dot(self, other)
 
-    __matmul__ = dot
+    def __matmul__(self, other):
+        try:
+            return dot(self, other)
+        except AttributeError:
+            return dot(self, np.array(other))
 
     def __rmatmul__(self, other):
         return dot(np.array(other), self)

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -695,7 +695,7 @@ def dot(a, b, make_array=True):
             a = np.array(a)
         if not hasattr(b, 'ndim'):
             b = np.array(b)
-    return tensordot(a, b, axes=((a.ndim-1,), (b.ndim-2,)))
+    return tensordot(a, b, axes=((a.ndim - 1,), (b.ndim - 2,)))
 
 
 def _dot(a, b):

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -331,7 +331,7 @@ class COO(object):
     __matmul__ = dot
 
     def __rmatmul__(self, other):
-        return dot(other, self)
+        return dot(np.array(other), self)
 
     def reshape(self, shape):
         if self.shape == shape:

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -140,6 +140,7 @@ def test_dot():
     if sys.version_info >= (3, 5):
         assert_eq(eval("a @ b"), eval("sa @ sb"))
         assert_eq(eval("sa @ sb"), sparse.dot(sa, sb))
+        assert_eq(eval("a @ sb"), sparse.dot(a, sb))
 
 
 @pytest.mark.parametrize('func', [np.expm1, np.log1p, np.sin, np.tan,

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -130,6 +130,7 @@ def test_tensordot(a_shape, b_shape, axes):
 def test_dot():
     a = random_x((3, 4, 5))
     b = random_x((5, 6))
+    lol = [[1, 2, 3, 4, 5]]
 
     sa = COO.from_numpy(a)
     sb = COO.from_numpy(b)
@@ -140,7 +141,7 @@ def test_dot():
     if sys.version_info >= (3, 5):
         assert_eq(eval("a @ b"), eval("sa @ sb"))
         assert_eq(eval("sa @ sb"), sparse.dot(sa, sb))
-        assert_eq(eval("a @ sb"), sparse.dot(a, sb))
+        assert_eq(eval("lol @ b"), eval("lol @ sb"))
 
 
 @pytest.mark.parametrize('func', [np.expm1, np.log1p, np.sin, np.tan,

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -131,6 +131,7 @@ def test_dot():
     a = random_x((3, 4, 5))
     b = random_x((5, 6))
     l = [1, 2, 3, 4, 5]
+    l # silencing flake8
 
     sa = COO.from_numpy(a)
     sb = COO.from_numpy(b)

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -130,7 +130,7 @@ def test_tensordot(a_shape, b_shape, axes):
 def test_dot():
     a = random_x((3, 4, 5))
     b = random_x((5, 6))
-    lol = [[1, 2, 3, 4, 5]]
+    l = [1, 2, 3, 4, 5]
 
     sa = COO.from_numpy(a)
     sb = COO.from_numpy(b)
@@ -141,7 +141,8 @@ def test_dot():
     if sys.version_info >= (3, 5):
         assert_eq(eval("a @ b"), eval("sa @ sb"))
         assert_eq(eval("sa @ sb"), sparse.dot(sa, sb))
-        assert_eq(eval("lol @ b"), eval("lol @ sb"))
+        assert_eq(eval("l @ b"), eval("l @ sb"))     # __rmatmul__
+        assert_eq(eval("a @ sb"), sparse.dot(a, sb)) # __rmatmul__
 
 
 @pytest.mark.parametrize('func', [np.expm1, np.log1p, np.sin, np.tan,

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -1,5 +1,6 @@
 import pytest
 
+import sys
 import random
 import operator
 import numpy as np
@@ -135,6 +136,10 @@ def test_dot():
 
     assert_eq(a.dot(b), sa.dot(sb))
     assert_eq(np.dot(a, b), sparse.dot(sa, sb))
+
+    if sys.version_info >= (3, 5):
+        assert_eq(eval("a @ b"), eval("sa @ sb"))
+        assert_eq(eval("sa @ sb"), sparse.dot(sa, sb))
 
 
 @pytest.mark.parametrize('func', [np.expm1, np.log1p, np.sin, np.tan,


### PR DESCRIPTION
Assuming we can merge the minimal https://github.com/mrocklin/sparse/pull/16 that simply implements the `@` operator for known types, this is proposal 1 for behavior with lists/tuples.

The gist of this approach is that if a user want to coerce lists to arrays, they must either explicitly create COOs with that behavior as `COO(..., toarray_other=True)` or call `sparse.dot(..., make_array=True)` (or `my_coo.dot(..., make_array=True)`).

Test for both success and failure are included for these opt-in behaviors.