### PR TITLE
Improve the source release for PyPI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE.txt
+recursive-include sparse *.py


### PR DESCRIPTION
The current tarball distributed on PyPI is missing some files required for producing quality binary packages for Linux distributions.

In addition to the `README.rst` and package content, which `sdist` handles by default, this commit adds the licensing terms (also added by default if the file were named `LICENSE`) and the test suite, which is helpful for continuous integration purposes.