### PR TITLE
Reshape without coords sacling

### DIFF
--- a/sparse/core.py
+++ b/sparse/core.py
@@ -292,16 +292,16 @@ class COO(object):
         value
             the value to write
         """
-
+        # TODO: what if coordinates are too big for dtype of coords?
         # TODO: check input
         # search for index in coords and get it's position if present
         # TODO: speedup by not checking every possible position in every dimension
         coord_ids = None
         for i, ind in enumerate(index):
             # keep only the positions that occure in every dimension
-            coord_ids_i = np.where(self.coords[i] == ind)[0]
+            coord_ids_i = np.asarray(np.where(self.coords[i] == ind)[0],dtype=self.coords.dtype)
             if coord_ids is not None:
-                coord_ids = np.intersect1d(coord_ids, coord_ids_i)
+                coord_ids = np.asarray(np.intersect1d(coord_ids, coord_ids_i),dtype=self.coords.dtype)
             else:
                 coord_ids = coord_ids_i
 
@@ -314,7 +314,7 @@ class COO(object):
             # TODO: test writing zeros
             # remove entry that should be set to zero
             else:
-                self.coords = np.delete(self.coords, coord_ids[0], 1)
+                self.coords = np.delete(self.coords, coord_ids[0], 1) #keeps dtype type
                 self.data = np.delete(self.data, coord_ids[0], 0)
 
         # found no value for index, append a new non-zero value
@@ -322,7 +322,7 @@ class COO(object):
             # only take action if a non-zero value shoud be set
             #  this adds a new value
             if (value != 0):
-                addIndex = [[index[i]] for i in range(len(index))]
+                addIndex = np.asarray([[index[i]] for i in range(len(index))],dtype=self.coords.dtype)
                 self.coords = np.concatenate((self.coords, addIndex), axis=1)
                 self.data = np.concatenate((self.data, [value]))
                 self.sorted = False

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -458,7 +458,21 @@ class COO(object):
             strides *= d
         return out
 
-    def reshape(self, shape):
+    def reshape(self, shape, scale=True):
+        """
+        Gives a new shape to an COO without changing its data.
+        Parameters
+        ----------
+        shape : int or tuple of ints
+            The new shape should be compatible with the original shape. If an integer, then the result will be a 1-D array of that length. One shape dimension can be -1. In this case, the value is inferred from the length of the array and remaining dimensions.
+        scale : bool, optional
+            If False (default) coordinates of values are be scaled with the shape. Else if True the coordinates stay the same.
+
+        Returns
+        -------
+        COO
+            new reshaped COO
+        """
         if self.shape == shape:
             return self
         if any(d == -1 for d in shape):
@@ -476,12 +490,14 @@ class COO(object):
 
         # TODO: this np.prod(self.shape) enforces a 2**64 limit to array size
         linear_loc = self.linear_loc()
-
-        coords = np.empty((len(shape), self.nnz), dtype=np.min_scalar_type(max(shape)))
-        strides = 1
-        for i, d in enumerate(shape[::-1]):
-            coords[-(i + 1), :] = (linear_loc // strides) % d
-            strides *= d
+        if scale:
+            coords = np.empty((len(shape), self.nnz), dtype=np.min_scalar_type(max(shape)))
+            strides = 1
+            for i, d in enumerate(shape[::-1]):
+                coords[-(i + 1), :] = (linear_loc // strides) % d
+                strides *= d
+        else:
+            coords = self.coords
 
         result = COO(coords, self.data, shape,
                      has_duplicates=self.has_duplicates,

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -299,7 +299,7 @@ class COO(object):
         coord_ids = None
         for i, ind in enumerate(index):
             # keep only the positions that occure in every dimension
-            coord_ids_i  =  np.where(self.coords[i] == ind)[0]
+            coord_ids_i = np.where(self.coords[i] == ind)[0]
             if coord_ids is not None:
                 coord_ids = np.intersect1d(coord_ids, coord_ids_i)
             else:
@@ -308,7 +308,7 @@ class COO(object):
         # found an value for index, replace it
         if len(coord_ids) == 1:
             # replace value
-            if(value != 0):
+            if (value != 0):
                 coords_id = coord_ids[0]
                 self.data[coords_id] = value
             # TODO: test writing zeros
@@ -317,19 +317,18 @@ class COO(object):
                 self.coords = np.delete(self.coords, coord_ids[0], 1)
                 self.data = np.delete(self.data, coord_ids[0], 0)
 
-
         # found no value for index, append a new non-zero value
         elif len(coord_ids) == 0:
             # only take action if a non-zero value shoud be set
             #  this adds a new value
-            if(value != 0):
+            if (value != 0):
                 addIndex = [[index[i]] for i in range(len(index))]
                 self.coords = np.concatenate((self.coords, addIndex), axis=1)
                 self.data = np.concatenate((self.data, [value]))
                 self.sorted = False
 
         else:
-            raise RuntimeError("COO is corrupt. There are multiple values assigned for "+index+".")
+            raise RuntimeError("COO is corrupt. There are multiple values assigned for " + index + ".")
 
     def __str__(self):
         return "<COO: shape=%s, dtype=%s, nnz=%d, sorted=%s, duplicates=%s>" % (

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -511,6 +511,6 @@ def test___setitem__():
         x = random_x((2, 3, 4))
         xx = COO.from_numpy(x)
         ranNumber = random.randint(-1, 1)
-        x[1,2,3] = ranNumber
-        xx[1,2,3] = ranNumber
+        x[1, 2, 3] = ranNumber
+        xx[1, 2, 3] = ranNumber
         assert_eq(x, xx)

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -504,3 +504,13 @@ def test_caching():
         x.reshape((1,) * i + (2,) + (1,) * (x.ndim - i - 1))
 
     assert len(x._cache['reshape']) < 5
+
+
+def test___setitem__():
+    for i in range(100):
+        x = random_x((2, 3, 4))
+        xx = COO.from_numpy(x)
+        ranNumber = random.randint(-1, 1)
+        x[1,2,3] = ranNumber
+        xx[1,2,3] = ranNumber
+        assert_eq(x, xx)

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -514,3 +514,31 @@ def test___setitem__():
         x[1, 2, 3] = ranNumber
         xx[1, 2, 3] = ranNumber
         assert_eq(x, xx)
+
+def test_reshape_ok():
+    dims = 3
+    coords = np.asarray([[0],[1],[1]])
+    data = np.asarray([True], dtype=bool)
+    shape = (2,) * dims
+    x = COO(coords=coords, data=data, shape=shape)
+    new_shape1 = (4,) * dims
+    y = x.reshape(shape=new_shape1)
+
+    new_shape2 = (8,) * dims
+    z = y.reshape(shape=new_shape2)
+    print("")
+
+def test_reshape():
+    dims = 3
+    coords = np.asarray([])
+    data =  np.asarray([],dtype=bool)
+    shape = (2,)*dims
+    x = COO(coords=coords,data=data,shape=shape)
+    new_shape1 = (4,)*dims
+    y = x.reshape(shape=new_shape1)
+
+    y[1,2,3] = True
+
+    new_shape2 = (8,) * dims
+    z = y.reshape(shape=new_shape2)
+    print("")


### PR DESCRIPTION
For my use case I need to be able to enlarge the tensor without coordinates of non-zero entries to change. So here is a proposal for discussion if and how to implement this feature.