### PR TITLE
Elementwise and and or

### DIFF
--- a/sparse/core.py
+++ b/sparse/core.py
@@ -8,7 +8,6 @@ import operator
 import numpy as np
 import scipy.sparse
 
-
 try:  # Windows compatibility
     int = long
 except NameError:
@@ -589,6 +588,15 @@ class COO(object):
 
     def __pow__(self, other):
         return self.elemwise(operator.pow, other)
+
+    def __and__(self, other):
+        return self.elemwise_binary(operator.and_, other)
+
+    def __or__(self, other):
+        return self.elemwise_binary(operator.or_, other)
+
+    def __xor__(self, other):
+        return self.elemwise_binary(operator.xor, other)
 
     def elemwise(self, func, *args, **kwargs):
         if kwargs.pop('check', True) and func(0, *args, **kwargs) != 0:

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -648,9 +648,9 @@ class COO(object):
         data = np.concatenate([func(self_data[matched_self],
                                     other_data[matched_other],
                                     *args, **kwargs),
-                               func(self_data[unmatched_self], 0,
+                               func(self_data[unmatched_self], False,
                                     *args, **kwargs),
-                               func(0, other_data[unmatched_other],
+                               func(False, other_data[unmatched_other],
                                     *args, **kwargs)])
         coords = np.concatenate([self_coords[matched_self],
                                  self_coords[unmatched_self],

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -200,6 +200,23 @@ def test_elemwise_binary_empty():
         assert z.coords.shape == (2, 0)
         assert z.data.shape == (0,)
 
+def test_elemwise_binary_OR():
+    size = 3
+    dimension = 3
+
+    coords1 = np.ndarray(shape=(0,))
+    data1 = np.ndarray(shape=(0,), dtype=bool)
+    tensor1 = COO(data=data1, coords=coords1,shape=((size,) * dimension))
+
+    coords2 = np.asarray(a=[[0], [1], [2]])
+    data2 = np.asarray(a=[True], dtype=bool)
+    tensor2 = COO(coords=coords2, data=data2, shape=((size,) * dimension))
+
+    resultTensor = tensor1.elemwise_binary(func=operator.or_, other=tensor2)
+    print('\nresultTensor = emptyTensor | oneElementTensor')
+    print(resultTensor.todense())
+    print("")
+
 
 def test_gt():
     x = random_x((2, 3, 4))

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -25,6 +25,13 @@ def random_x(shape, dtype=float):
     return x
 
 
+def random_x_bool(shape):
+    x = np.zeros(shape=shape, dtype=bool)
+    for i in range(max(5, np.prod(x.shape) // 10)):
+        x[tuple(random.randint(0, d - 1) for d in x.shape)] = bool(random.randint(0, 1))
+    return x
+
+
 @pytest.mark.parametrize('reduction,kwargs', [
     ('max', {}),
     ('sum', {}),
@@ -200,22 +207,22 @@ def test_elemwise_binary_empty():
         assert z.coords.shape == (2, 0)
         assert z.data.shape == (0,)
 
+
 def test_elemwise_binary_OR():
     size = 3
     dimension = 3
+    shape = ((size,) * dimension)
 
-    coords1 = np.ndarray(shape=(0,))
-    data1 = np.ndarray(shape=(0,), dtype=bool)
-    tensor1 = COO(data=data1, coords=coords1,shape=((size,) * dimension))
+    x = np.zeros(shape=shape,dtype=bool)
+    xx = COO.from_numpy(x)
 
-    coords2 = np.asarray(a=[[0], [1], [2]])
-    data2 = np.asarray(a=[True], dtype=bool)
-    tensor2 = COO(coords=coords2, data=data2, shape=((size,) * dimension))
+    y = np.zeros(shape=shape,dtype=bool)
+    y[0,1,2] = True
+    yy = COO.from_numpy(y)
 
-    resultTensor = tensor1.elemwise_binary(func=operator.or_, other=tensor2)
-    print('\nresultTensor = emptyTensor | oneElementTensor')
-    print(resultTensor.todense())
-    print("")
+    z = x | y
+    zz = xx.elemwise_binary(func=operator.or_, other=yy)
+    assert_eq(z,zz)
 
 
 def test_gt():
@@ -407,6 +414,36 @@ def test_scalar_exponentiation():
 
     with pytest.raises((ValueError, ZeroDivisionError)):
         assert_eq(x ** -1, a ** -1)
+
+
+def test_bit_and():
+    x = random_x_bool((2, 3, 4))
+    xx = COO.from_numpy(x)
+
+    y = random_x_bool((2, 3, 4))
+    yy = COO.from_numpy(y)
+
+    assert_eq(x & y, xx & yy)
+
+
+def test_bit_or():
+    x = random_x_bool((2, 3, 4))
+    xx = COO.from_numpy(x)
+
+    y = random_x_bool((2, 3, 4))
+    yy = COO.from_numpy(y)
+
+    assert_eq(x | y, xx | yy)
+
+
+def test_bit_xor():
+    x = random_x_bool((2, 3, 4))
+    xx = COO.from_numpy(x)
+
+    y = random_x_bool((2, 3, 4))
+    yy = COO.from_numpy(y)
+
+    assert_eq(x ^ y, xx ^ yy)
 
 
 def test_create_with_lists_of_tuples():

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -19,7 +19,7 @@ y = COO.from_numpy(x)
 
 
 def random_x(shape, dtype=float):
-    x = np.zeros(shape=shape, dtype=float)
+    x = np.zeros(shape=shape, dtype=dtype)
     for i in range(max(5, np.prod(x.shape) // 10)):
         x[tuple(random.randint(0, d - 1) for d in x.shape)] = random.randint(0, 100)
     return x
@@ -416,7 +416,7 @@ def test_scalar_exponentiation():
         assert_eq(x ** -1, a ** -1)
 
 
-def test_bit_and():
+def test_bool_and():
     x = random_x_bool((2, 3, 4))
     xx = COO.from_numpy(x)
 
@@ -426,7 +426,17 @@ def test_bit_and():
     assert_eq(x & y, xx & yy)
 
 
-def test_bit_or():
+def test_int_and():
+    x = random_x((2, 3, 4), dtype=int)
+    xx = COO.from_numpy(x)
+
+    y = random_x((2, 3, 4), dtype=int)
+    yy = COO.from_numpy(y)
+
+    assert_eq((x & y), (xx & yy))
+
+
+def test_bool_or():
     x = random_x_bool((2, 3, 4))
     xx = COO.from_numpy(x)
 
@@ -436,11 +446,31 @@ def test_bit_or():
     assert_eq(x | y, xx | yy)
 
 
-def test_bit_xor():
+def test_int_or():
+    x = random_x((2, 3, 4), dtype=int)
+    xx = COO.from_numpy(x)
+
+    y = random_x((2, 3, 4), dtype=int)
+    yy = COO.from_numpy(y)
+
+    assert_eq(x | y, xx | yy)
+
+
+def test_bool_xor():
     x = random_x_bool((2, 3, 4))
     xx = COO.from_numpy(x)
 
     y = random_x_bool((2, 3, 4))
+    yy = COO.from_numpy(y)
+
+    assert_eq(x ^ y, xx ^ yy)
+
+
+def test_int_xor():
+    x = random_x((2, 3, 4), dtype=int)
+    xx = COO.from_numpy(x)
+
+    y = random_x((2, 3, 4), dtype=int)
     yy = COO.from_numpy(y)
 
     assert_eq(x ^ y, xx ^ yy)


### PR DESCRIPTION
This resolves #25. 
Additionally it introduce the element-wise binary operators AND `&`, OR `|` and XOR `^` on any COO holding Integral values (that includes especially long, int and bool). 