### PR TITLE
implemented __setitem__

### DIFF
--- a/sparse/core.py
+++ b/sparse/core.py
@@ -292,7 +292,6 @@ class COO(object):
         value
             the value to write
         """
-        # TODO: what if coordinates are too big for dtype of coords?
         # TODO: check input
         # search for index in coords and get it's position if present
         # TODO: speedup by not checking every possible position in every dimension

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -292,16 +292,16 @@ class COO(object):
         value
             the value to write
         """
-
+        # TODO: what if coordinates are too big for dtype of coords?
         # TODO: check input
         # search for index in coords and get it's position if present
         # TODO: speedup by not checking every possible position in every dimension
         coord_ids = None
         for i, ind in enumerate(index):
             # keep only the positions that occure in every dimension
-            coord_ids_i = np.where(self.coords[i] == ind)[0]
+            coord_ids_i = np.asarray(np.where(self.coords[i] == ind)[0],dtype=self.coords.dtype)
             if coord_ids is not None:
-                coord_ids = np.intersect1d(coord_ids, coord_ids_i)
+                coord_ids = np.asarray(np.intersect1d(coord_ids, coord_ids_i),dtype=self.coords.dtype)
             else:
                 coord_ids = coord_ids_i
 
@@ -314,7 +314,7 @@ class COO(object):
             # TODO: test writing zeros
             # remove entry that should be set to zero
             else:
-                self.coords = np.delete(self.coords, coord_ids[0], 1)
+                self.coords = np.delete(self.coords, coord_ids[0], 1) #keeps dtype type
                 self.data = np.delete(self.data, coord_ids[0], 0)
 
         # found no value for index, append a new non-zero value
@@ -322,7 +322,7 @@ class COO(object):
             # only take action if a non-zero value shoud be set
             #  this adds a new value
             if (value != 0):
-                addIndex = [[index[i]] for i in range(len(index))]
+                addIndex = np.asarray([[index[i]] for i in range(len(index))],dtype=self.coords.dtype)
                 self.coords = np.concatenate((self.coords, addIndex), axis=1)
                 self.data = np.concatenate((self.data, [value]))
                 self.sorted = False

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -299,7 +299,7 @@ class COO(object):
         coord_ids = None
         for i, ind in enumerate(index):
             # keep only the positions that occure in every dimension
-            coord_ids_i  =  np.where(self.coords[i] == ind)[0]
+            coord_ids_i = np.where(self.coords[i] == ind)[0]
             if coord_ids is not None:
                 coord_ids = np.intersect1d(coord_ids, coord_ids_i)
             else:
@@ -308,7 +308,7 @@ class COO(object):
         # found an value for index, replace it
         if len(coord_ids) == 1:
             # replace value
-            if(value != 0):
+            if (value != 0):
                 coords_id = coord_ids[0]
                 self.data[coords_id] = value
             # TODO: test writing zeros
@@ -317,19 +317,18 @@ class COO(object):
                 self.coords = np.delete(self.coords, coord_ids[0], 1)
                 self.data = np.delete(self.data, coord_ids[0], 0)
 
-
         # found no value for index, append a new non-zero value
         elif len(coord_ids) == 0:
             # only take action if a non-zero value shoud be set
             #  this adds a new value
-            if(value != 0):
+            if (value != 0):
                 addIndex = [[index[i]] for i in range(len(index))]
                 self.coords = np.concatenate((self.coords, addIndex), axis=1)
                 self.data = np.concatenate((self.data, [value]))
                 self.sorted = False
 
         else:
-            raise RuntimeError("COO is corrupt. There are multiple values assigned for "+index+".")
+            raise RuntimeError("COO is corrupt. There are multiple values assigned for " + index + ".")
 
     def __str__(self):
         return "<COO: shape=%s, dtype=%s, nnz=%d, sorted=%s, duplicates=%s>" % (

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -511,6 +511,6 @@ def test___setitem__():
         x = random_x((2, 3, 4))
         xx = COO.from_numpy(x)
         ranNumber = random.randint(-1, 1)
-        x[1,2,3] = ranNumber
-        xx[1,2,3] = ranNumber
+        x[1, 2, 3] = ranNumber
+        xx[1, 2, 3] = ranNumber
         assert_eq(x, xx)

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -506,6 +506,49 @@ def test_caching():
     assert len(x._cache['reshape']) < 5
 
 
+def test___setitem__input1():
+    # assign to single dimensional
+    sd = random_x((5,))
+    ssdd = COO.from_numpy(sd)
+    sd_val = random.randint(-1, 1)
+    sd[3] = sd_val
+    ssdd[3] = sd_val
+    assert_eq(sd, ssdd)
+
+
+def test___setitem__input2():
+    with pytest.raises(NotImplementedError):
+        # TODO: remove this for loop when slices are supported
+        # slices sould raise an exception
+        sl = random_x((5,))
+        ssll = COO.from_numpy(sl)
+        ssll[0:1] = [1, 1]
+
+
+def test___setitem__input3():
+    with pytest.raises(ValueError):
+        # none numbers.Integral and slices should raise an exception
+        wv = random_x((5, 5))
+        wwvv = COO.from_numpy(wv)
+        wwvv["a"] = 3
+
+
+def test___setitem__input4():
+    with pytest.raises(ValueError):
+        # indices of wrong length should raise an exception
+        wl = random_x((5, 5))
+        wwll = COO.from_numpy(wl)
+        wwll[1] = 3
+
+
+def test___setitem__input5():
+    with pytest.raises(ValueError):
+        # indices with entries out of their dimensions range should raise an exception
+        dr = random_x((5, 5))
+        ddrr = COO.from_numpy(dr)
+        ddrr[10] = 3
+
+
 def test___setitem__():
     for i in range(100):
         x = random_x((2, 3, 4))
@@ -515,30 +558,18 @@ def test___setitem__():
         xx[1, 2, 3] = ranNumber
         assert_eq(x, xx)
 
-def test_reshape_ok():
+
+def test_reshape_with__setitem__():
+    # exception is thrown if COO.coords.dtype is not minimal, see: COO.linear_loc
     dims = 3
-    coords = np.asarray([[0],[1],[1]])
-    data = np.asarray([True], dtype=bool)
+    coords = np.asarray([])
+    data = np.asarray([], dtype=bool)
     shape = (2,) * dims
     x = COO(coords=coords, data=data, shape=shape)
     new_shape1 = (4,) * dims
     y = x.reshape(shape=new_shape1)
 
-    new_shape2 = (8,) * dims
-    z = y.reshape(shape=new_shape2)
-    print("")
-
-def test_reshape():
-    dims = 3
-    coords = np.asarray([])
-    data =  np.asarray([],dtype=bool)
-    shape = (2,)*dims
-    x = COO(coords=coords,data=data,shape=shape)
-    new_shape1 = (4,)*dims
-    y = x.reshape(shape=new_shape1)
-
-    y[1,2,3] = True
+    y[1, 2, 3] = True
 
     new_shape2 = (8,) * dims
     z = y.reshape(shape=new_shape2)
-    print("")

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -504,3 +504,13 @@ def test_caching():
         x.reshape((1,) * i + (2,) + (1,) * (x.ndim - i - 1))
 
     assert len(x._cache['reshape']) < 5
+
+
+def test___setitem__():
+    for i in range(100):
+        x = random_x((2, 3, 4))
+        xx = COO.from_numpy(x)
+        ranNumber = random.randint(-1, 1)
+        x[1,2,3] = ranNumber
+        xx[1,2,3] = ranNumber
+        assert_eq(x, xx)

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -514,3 +514,31 @@ def test___setitem__():
         x[1, 2, 3] = ranNumber
         xx[1, 2, 3] = ranNumber
         assert_eq(x, xx)
+
+def test_reshape_ok():
+    dims = 3
+    coords = np.asarray([[0],[1],[1]])
+    data = np.asarray([True], dtype=bool)
+    shape = (2,) * dims
+    x = COO(coords=coords, data=data, shape=shape)
+    new_shape1 = (4,) * dims
+    y = x.reshape(shape=new_shape1)
+
+    new_shape2 = (8,) * dims
+    z = y.reshape(shape=new_shape2)
+    print("")
+
+def test_reshape():
+    dims = 3
+    coords = np.asarray([])
+    data =  np.asarray([],dtype=bool)
+    shape = (2,)*dims
+    x = COO(coords=coords,data=data,shape=shape)
+    new_shape1 = (4,)*dims
+    y = x.reshape(shape=new_shape1)
+
+    y[1,2,3] = True
+
+    new_shape2 = (8,) * dims
+    z = y.reshape(shape=new_shape2)
+    print("")

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -567,9 +567,9 @@ def test_reshape_with__setitem__():
     shape = (2,) * dims
     x = COO(coords=coords, data=data, shape=shape)
     new_shape1 = (4,) * dims
-    y = x.reshape(shape=new_shape1)
+    x = x.reshape(shape=new_shape1)
 
-    y[1, 2, 3] = True
+    x[1, 2, 3] = True
 
     new_shape2 = (8,) * dims
-    z = y.reshape(shape=new_shape2)
+    x = x.reshape(shape=new_shape2)


### PR DESCRIPTION
this partly resolves #15. It supports setting values in COOs like:
```
x = COO.from_numpy(np.zeros(shape=(5,5)))
x[1,2] = 5
```
It does not support slices so far. So values aren't set in form of structures like arrays but as simply as scalars.

The index format is compatible with `np.ndarray`but does not match `sparse.COO`'s format for get: 
```
value = x[[1],[2]]
```
That leads to the following unequitation:
```
x = COO.from_numpy(np.zeros(shape=(5,5)))
value = 1
x[1,2] = value 
get_value = x[[1],[2]]
assert value != get_value
``` 
here value is an int and get_value is an COO of shape (1,1).
