### PR TITLE
Remove auto densification and unify operator code.

### DIFF
--- a/sparse/core.py
+++ b/sparse/core.py
@@ -651,6 +651,7 @@ class COO(object):
             function. Otherwise, it will be treated as a unary function.
         kwargs : dict, optional
             The kwargs to pass to the function.
+
         Returns
         -------
         COO

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -624,7 +624,7 @@ class COO(object):
 
     def __or__(self, other):
         return self._perform_op(other, operator.or_)
-    
+
     def __gt__(self, other):
         return self._perform_op(other, operator.gt)
 

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -624,6 +624,24 @@ class COO(object):
 
     def __or__(self, other):
         return self._perform_op(other, operator.or_)
+    
+    def __gt__(self, other):
+        return self._perform_op(other, operator.gt)
+
+    def __ge__(self, other):
+        return self._perform_op(other, operator.ge)
+
+    def __lt__(self, other):
+        return self._perform_op(other, operator.lt)
+
+    def __le__(self, other):
+        return self._perform_op(other, operator.le)
+
+    def __eq__(self, other):
+        return self._perform_op(other, operator.eq)
+
+    def __ne__(self, other):
+        return self._perform_op(other, operator.ne)
 
     def elemwise(self, func, *args, **kwargs):
         check = kwargs.pop('check', True)
@@ -1117,22 +1135,6 @@ class COO(object):
     def astype(self, dtype, out=None):
         assert out is None
         return self.elemwise(np.ndarray.astype, dtype, check=False)
-
-    def __gt__(self, other):
-        if not isinstance(other, numbers.Number):
-            raise NotImplementedError("Only scalars supported")
-        if other < 0:
-            raise ValueError("Comparison with negative number would produce "
-                             "dense result")
-        return self.elemwise(operator.gt, other)
-
-    def __ge__(self, other):
-        if not isinstance(other, numbers.Number):
-            raise NotImplementedError("Only scalars supported")
-        if other <= 0:
-            raise ValueError("Comparison with negative number would produce "
-                             "dense result")
-        return self.elemwise(operator.ge, other)
 
     def maybe_densify(self, allowed_nnz=1e3, allowed_fraction=0.25):
         """ Convert to a dense numpy array if not too costly.  Err othrewise """

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -579,14 +579,8 @@ class COO(object):
 
         return self
 
-    def _perform_op(self, other, op):
-        if isinstance(other, COO):
-            return self.elemwise_binary(op, other)
-        else:
-            return self.elemwise(op, other)
-
     def __add__(self, other):
-        return self._perform_op(other, operator.add)
+        return self.elemwise_binary(operator.add, other)
 
     __radd__ = __add__
 
@@ -595,53 +589,53 @@ class COO(object):
                    self.sorted)
 
     def __sub__(self, other):
-        return self._perform_op(other, operator.sub)
+        return self.elemwise_binary(operator.sub, other)
 
     def __rsub__(self, other):
         return -(self - other)
 
     def __mul__(self, other):
-        return self._perform_op(other, operator.mul)
+        return self.elemwise_binary(operator.mul, other)
 
     __rmul__ = __mul__
 
     def __truediv__(self, other):
-        return self._perform_op(other, operator.truediv)
+        return self.elemwise_binary(operator.truediv, other)
 
     def __floordiv__(self, other):
-        return self._perform_op(other, operator.floordiv)
+        return self.elemwise_binary(operator.floordiv, other)
 
     __div__ = __truediv__
 
     def __pow__(self, other):
-        return self._perform_op(other, operator.pow)
+        return self.elemwise_binary(operator.pow, other)
 
     def __and__(self, other):
-        return self._perform_op(other, operator.and_)
+        return self.elemwise_binary(operator.and_, other)
 
     def __xor__(self, other):
-        return self._perform_op(other, operator.xor)
+        return self.elemwise_binary(operator.xor, other)
 
     def __or__(self, other):
-        return self._perform_op(other, operator.or_)
+        return self.elemwise_binary(operator.or_, other)
 
     def __gt__(self, other):
-        return self._perform_op(other, operator.gt)
+        return self.elemwise_binary(operator.gt, other)
 
     def __ge__(self, other):
-        return self._perform_op(other, operator.ge)
+        return self.elemwise_binary(operator.ge, other)
 
     def __lt__(self, other):
-        return self._perform_op(other, operator.lt)
+        return self.elemwise_binary(operator.lt, other)
 
     def __le__(self, other):
-        return self._perform_op(other, operator.le)
+        return self.elemwise_binary(operator.le, other)
 
     def __eq__(self, other):
-        return self._perform_op(other, operator.eq)
+        return self.elemwise_binary(operator.eq, other)
 
     def __ne__(self, other):
-        return self._perform_op(other, operator.ne)
+        return self.elemwise_binary(operator.ne, other)
 
     def elemwise(self, func, *args, **kwargs):
         check = kwargs.pop('check', True)
@@ -657,8 +651,7 @@ class COO(object):
 
     def elemwise_binary(self, func, other, *args, **kwargs):
         if not isinstance(other, COO):
-            raise ValueError("Performing this operation would produce "
-                             "a dense result: %s" % str(func))
+            return self.elemwise(func, other, *args, **kwargs)
 
         check = kwargs.pop('check', True)
         self_zero = _zero_of_dtype(self.dtype)

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -460,7 +460,9 @@ class COO(object):
         # TODO: this np.prod(self.shape) enforces a 2**64 limit to array size
         linear_loc = self.linear_loc()
 
-        coords = np.empty((len(shape), self.nnz), dtype=np.min_scalar_type(max(shape)))
+        max_shape = max(shape) if len(shape) != 0 else 1
+
+        coords = np.empty((len(shape), self.nnz), dtype=np.min_scalar_type(max_shape - 1))
         strides = 1
         for i, d in enumerate(shape[::-1]):
             coords[-(i + 1), :] = (linear_loc // strides) % d

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -214,6 +214,16 @@ def test_auto_densification_fails(func):
         func(xs, ys)
 
 
+def test_op_scipy_sparse():
+    x = random_x((3, 4))
+    y = random_x((3, 4))
+
+    xs = COO.from_numpy(x)
+    ys = scipy.sparse.csr_matrix(y)
+
+    assert_eq(x + y, xs + ys)
+
+
 @pytest.mark.parametrize('func, scalar', [
     (operator.mul, 5),
     (operator.add, 0),

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -233,6 +233,10 @@ def test_elemwise_scalar(func, scalar):
     y = scalar
 
     xs = COO.from_numpy(x)
+    fs = func(xs, y)
+
+    assert isinstance(fs, COO)
+    assert xs.nnz >= fs.nnz
 
     assert_eq(func(xs, y), func(x, y))
 
@@ -589,7 +593,7 @@ def test_cache_csr():
 
 
 def test_empty_shape():
-    x = COO([], [1.0])
+    x = COO(np.empty((0, 1), dtype=np.int8), [1.0])
     assert x.shape == ()
     assert ((2 * x).todense() == np.array(2.0)).all()
 

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -399,30 +399,19 @@ def test_addition():
 
     assert_eq(x + y, a + b)
     assert_eq(x - y, a - b)
-    assert_eq(-x, -a)
-
-
-def test_addition_ok_when_mostly_dense():
-    x = np.arange(10)
-    y = COO.from_numpy(x)
-
-    assert_eq(x + 1, y + 1)
-    assert_eq(x - 1, y - 1)
-    assert_eq(1 - x, 1 - y)
-    assert_eq(np.exp(x), np.exp(y))
 
 
 def test_addition_not_ok_when_large_and_sparse():
     x = COO({(0, 0): 1}, shape=(1000000, 1000000))
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         x + 1
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         1 + x
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         1 - x
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         x - 1
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         np.exp(x)
 
 

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -238,7 +238,7 @@ def test_elemwise_scalar(func, scalar):
     assert isinstance(fs, COO)
     assert xs.nnz >= fs.nnz
 
-    assert_eq(func(xs, y), func(x, y))
+    assert_eq(fs, func(x, y))
 
 
 @pytest.mark.parametrize('func, scalar', [


### PR DESCRIPTION
I've removed the auto-densification in `__add__` and `exp` and I've removed the tests for it. In addition, I've unified the code for all operators so that they only work when not densified. In addition, they work with scalars if the scalars don't densify them.