### PR TITLE
Copy constructor

### DIFF
--- a/sparse/core.py
+++ b/sparse/core.py
@@ -111,6 +111,15 @@ class COO(object):
                 coords = list(coords.items())
                 has_duplicates = False
 
+            if isinstance(coords, COO):
+                self.coords = coords.coords
+                self.data = coords.data
+                self.has_duplicates = coords.has_duplicates
+                self.sorted = coords.sorted
+                self.shape = coords.shape
+                return
+
+
             if isinstance(coords, np.ndarray):
                 result = COO.from_numpy(coords)
                 self.coords = result.coords
@@ -1336,7 +1345,7 @@ def _mask(coords, idx):
 
 
 def concatenate(arrays, axis=0):
-    arrays = [x if type(x) is COO else COO(x) for x in arrays]
+    arrays = [COO(x) for x in arrays]
     if axis < 0:
         axis = axis + arrays[0].ndim
     assert all(x.shape[ax] == arrays[0].shape[ax]
@@ -1366,7 +1375,7 @@ def concatenate(arrays, axis=0):
 
 def stack(arrays, axis=0):
     assert len(set(x.shape for x in arrays)) == 1
-    arrays = [x if type(x) is COO else COO(x) for x in arrays]
+    arrays = [COO(x) for x in arrays]
     if axis < 0:
         axis = axis + arrays[0].ndim + 1
     data = np.concatenate([x.data for x in arrays])


### PR DESCRIPTION
This is inspired by NumPy's behaviour, where people tend to do `numpy.array(a)` on any iterable `a`, including `ndarray`s, just to make sure it is an `ndarray`.

Do you think something like this would make sense? Would save us having to do type checks in places where we just want to make sure it is a `COO` instance.