### PR TITLE
Add lots of indexing features.

### DIFF
--- a/sparse/core.py
+++ b/sparse/core.py
@@ -250,13 +250,8 @@ class COO(object):
             if isinstance(index, str):
                 data = self.data[index]
                 idx = np.where(data)
-                coords = []
-
-                for i in range(self.ndim):
-                    coords.append(self.coords[i, idx[0]])
-
-                for i in range(1, np.ndim(data)):
-                    coords.append(idx[i])
+                coords = list(self.coords[:, idx[0]])
+                coords.extend(idx[1:])
 
                 return COO(coords, data[idx].flatten(),
                            shape=self.shape + self.data.dtype[index].shape,

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -311,7 +311,7 @@ class COO(object):
                         start = stop
                     shape.append((start - stop - step - 1) // (-step))
 
-                dt = np.min_scalar_type(min(-(l - 1) if l != 0 else -1 for l in shape))
+                dt = np.min_scalar_type(min(-(dim - 1) if dim != 0 else -1 for dim in shape))
                 coords.append((self.coords[i, mask].astype(dt) - start) // step)
                 i += 1
             elif isinstance(ind, list):

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -245,26 +245,43 @@ class COO(object):
 
     def __getitem__(self, index):
         if not isinstance(index, tuple):
-            index = (index,)
+            if isinstance(index, str):
+                data = self.data[index]
+                idx = np.where(data)
+                coords = []
+
+                for i in range(self.ndim):
+                    coords.append(self.coords[i, idx[0]])
+
+                for i in range(1, np.ndim(data)):
+                    coords.append(idx[i])
+
+                return COO(coords, data.flatten(),
+                           shape=self.shape + self.data.dtype[index].shape,
+                           has_duplicates=self.has_duplicates,
+                           sorted=self.sorted)
+            else:
+                index = (index,)
+
+        last_ellipsis = False
+
         if len(index) - index.count(None) - index.count(Ellipsis) > self.ndim:
             raise IndexError("too many indices for array")
         if index.count(Ellipsis) > 1:
             raise IndexError("an index can only have a single ellipsis ('...')")
-        index = tuple(ind + self.shape[i]  # this fails for newaxis slices
-                      if isinstance(ind, numbers.Integral) and ind < 0
-                      else ind
-                      for i, ind in enumerate(index))
         if any(ind is Ellipsis for ind in index):
             loc = index.index(Ellipsis)
             n = self.ndim - (len(index) - 1 - index.count(None))
-            index = index[:loc] + (slice(None, None),) * n + index[loc + 1:]
-        if all(ind == slice(None) for ind in index):
+            if loc == len(index) - 1:
+                last_ellipsis = True
+            index = index[:loc] + (slice(None),) * n + index[loc + 1:]
+        if len(index) != 0 and all(ind == slice(None) for ind in index):
             return self
-        mask = np.ones(self.nnz, dtype=bool)
+        mask = np.ones(self.nnz, dtype=np.bool)
         for i, ind in enumerate([i for i in index if i is not None]):
-            if ind == slice(None, None):
+            if ind == slice(None):
                 continue
-            mask &= _mask(self.coords[i], ind)
+            mask &= _mask(self.coords[i], ind, self.shape[i], i)
 
         n = mask.sum()
         coords = []
@@ -275,10 +292,27 @@ class COO(object):
                 i += 1
                 continue
             elif isinstance(ind, slice):
-                start = ind.start or 0
-                stop = ind.stop if ind.stop is not None else self.shape[i]
-                shape.append(min(stop, self.shape[i]) - start)
-                coords.append(self.coords[i][mask] - start)
+
+                step = ind.step if ind.step is not None else 1
+                if step > 0:
+                    start = ind.start if ind.start is not None else 0
+                    start = max(start, 0)
+                    stop = ind.stop if ind.stop is not None else self.shape[i]
+                    stop = min(stop, self.shape[i])
+                    if start > stop:
+                        start = stop
+                    coords_temp_i = self.coords[i][mask] - start
+                    shape.append((stop - start + step - 1) // step)
+                else:
+                    start = ind.start or self.shape[i] - 1
+                    stop = ind.stop if ind.stop is not None else -1
+                    start = min(start, self.shape[i] - 1)
+                    stop = max(stop, -1)
+                    if start < stop:
+                        start = stop
+                    shape.append((start - stop - step - 1) // (-step))
+
+                coords.append((self.coords[i, mask] - start) // step)
                 i += 1
             elif isinstance(ind, list):
                 old = self.coords[i][mask]
@@ -299,7 +333,13 @@ class COO(object):
         if coords:
             coords = np.stack(coords, axis=0)
         else:
-            coords = np.empty((0, np.sum(mask)), dtype=np.uint8)
+            if last_ellipsis:
+                coords = np.empty((0, np.sum(mask)), dtype=np.uint8)
+            else:
+                if np.sum(mask) != 0:
+                    return self.data[mask][0]
+                else:
+                    return _zero_of_dtype(self.dtype)[()]
         shape = tuple(shape)
         data = self.data[mask]
 
@@ -1319,19 +1359,30 @@ def _keepdims(original, new, axis):
     return new.reshape(shape)
 
 
-def _mask(coords, idx):
+def _mask(coords, idx, shape, axis):
     if isinstance(idx, numbers.Integral):
+        if idx < -shape or idx >= shape:
+            raise IndexError('index %s is out of bounds for axis %s with size %s' %
+                             (idx, axis, shape))
+        if idx < 0:
+            idx = shape + idx
         return coords == idx
     elif isinstance(idx, slice):
-        if idx.step not in (1, None):
-            raise NotImplementedError("Steped slices not implemented")
-        start = idx.start if idx.start is not None else 0
-        stop = idx.stop if idx.stop is not None else np.inf
-        return (coords >= start) & (coords < stop)
-    elif isinstance(idx, list):
-        mask = np.zeros(len(coords), dtype=bool)
+        step = idx.step if idx.step is not None else 1
+        if step > 0:
+            start = idx.start if idx.start is not None else 0
+            stop = idx.stop if idx.stop is not None else shape
+            return (coords >= start) & (coords < stop) & \
+                   (coords % step == start % step)
+        else:
+            start = idx.start if idx.start is not None else (shape - 1)
+            stop = idx.stop if idx.stop is not None else -1
+            return (coords <= start) & (coords > stop) & \
+                   (coords % step == start % step)
+    elif isinstance(idx, Iterable):
+        mask = np.zeros(len(coords), dtype=np.bool)
         for item in idx:
-            mask |= coords == item
+            mask |= _mask(coords, item, shape, axis)
         return mask
 
 

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -301,7 +301,6 @@ class COO(object):
                     stop = min(stop, self.shape[i])
                     if start > stop:
                         start = stop
-                    coords_temp_i = self.coords[i][mask] - start
                     shape.append((stop - start + step - 1) // step)
                 else:
                     start = ind.start or self.shape[i] - 1

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -256,7 +256,7 @@ class COO(object):
                 for i in range(1, np.ndim(data)):
                     coords.append(idx[i])
 
-                return COO(coords, data.flatten(),
+                return COO(coords, data[idx].flatten(),
                            shape=self.shape + self.data.dtype[index].shape,
                            has_duplicates=self.has_duplicates,
                            sorted=self.sorted)

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -311,7 +311,8 @@ class COO(object):
                         start = stop
                     shape.append((start - stop - step - 1) // (-step))
 
-                coords.append((self.coords[i, mask] - start) // step)
+                dt = np.min_scalar_type(min(-(l - 1) if l != 0 else -1 for l in shape))
+                coords.append((self.coords[i, mask].astype(dt) - start) // step)
                 i += 1
             elif isinstance(ind, list):
                 old = self.coords[i][mask]

--- a/sparse/slicing.py
+++ b/sparse/slicing.py
@@ -135,7 +135,7 @@ def sanitize_index(ind):
     array([1, 2, 3])
     >>> sanitize_index(np.array([False, True, True]))
     array([1, 2])
-    >>> type(sanitize_index(np.int32(0)))
+    >>> type(sanitize_index(np.int32(0))) # doctest: +SKIP
     <type 'int'>
     >>> sanitize_index(1.0)
     1

--- a/sparse/slicing.py
+++ b/sparse/slicing.py
@@ -1,0 +1,260 @@
+# Most of this file is taken from https://github.com/dask/dask/blob/master/dask/array/slicing.py
+# See license at https://github.com/dask/dask/blob/master/LICENSE.txt
+
+import math
+from numbers import Integral, Number
+import numpy as np
+
+
+def normalize_index(idx, shape):
+    """ Normalize slicing indexes
+    1.  Replaces ellipses with many full slices
+    2.  Adds full slices to end of index
+    3.  Checks bounding conditions
+    4.  Replaces numpy arrays with lists
+    5.  Posify's integers and lists
+    6.  Normalizes slices to canonical form
+    Examples
+    --------
+    >>> normalize_index(1, (10,))
+    (1,)
+    >>> normalize_index(-1, (10,))
+    (9,)
+    >>> normalize_index([-1], (10,))
+    (array([9]),)
+    >>> normalize_index(slice(-3, 10, 1), (10,))
+    (slice(7, None, None),)
+    >>> normalize_index((Ellipsis, None), (10,))
+    (slice(None, None, None), None)
+    """
+    if not isinstance(idx, tuple):
+        idx = (idx,)
+    idx = replace_ellipsis(len(shape), idx)
+    n_sliced_dims = 0
+    for i in idx:
+        if hasattr(i, 'ndim') and i.ndim >= 1:
+            n_sliced_dims += i.ndim
+        elif i is None:
+            continue
+        else:
+            n_sliced_dims += 1
+    idx = idx + (slice(None),) * (len(shape) - n_sliced_dims)
+    if len([i for i in idx if i is not None]) > len(shape):
+        raise IndexError("Too many indices for array")
+
+    none_shape = []
+    i = 0
+    for ind in idx:
+        if ind is not None:
+            none_shape.append(shape[i])
+            i += 1
+        else:
+            none_shape.append(None)
+
+    for i, d in zip(idx, none_shape):
+        if d is not None:
+            check_index(i, d)
+    idx = tuple(map(sanitize_index, idx))
+    idx = tuple(map(normalize_slice, idx, none_shape))
+    idx = posify_index(none_shape, idx)
+    return idx
+
+
+def replace_ellipsis(n, index):
+    """ Replace ... with slices, :, : ,:
+    >>> replace_ellipsis(4, (3, Ellipsis, 2))
+    (3, slice(None, None, None), slice(None, None, None), 2)
+    >>> replace_ellipsis(2, (Ellipsis, None))
+    (slice(None, None, None), slice(None, None, None), None)
+    """
+    # Careful about using in or index because index may contain arrays
+    isellipsis = [i for i, ind in enumerate(index) if ind is Ellipsis]
+    if not isellipsis:
+        return index
+    elif len(isellipsis) > 1:
+        raise IndexError("an index can only have a single ellipsis ('...')")
+    else:
+        loc = isellipsis[0]
+    extra_dimensions = n - (len(index) - sum(i is None for i in index) - 1)
+    return index[:loc] + (slice(None, None, None),) * extra_dimensions + index[loc + 1:]
+
+
+def check_index(ind, dimension):
+    """ Check validity of index for a given dimension
+    Examples
+    --------
+    >>> check_index(3, 5)
+    >>> check_index(5, 5)
+    Traceback (most recent call last):
+    ...
+    IndexError: Index is not smaller than dimension 5 >= 5
+    >>> check_index(6, 5)
+    Traceback (most recent call last):
+    ...
+    IndexError: Index is not smaller than dimension 6 >= 5
+    >>> check_index(-1, 5)
+    >>> check_index(-6, 5)
+    Traceback (most recent call last):
+    ...
+    IndexError: Negative index is not greater than negative dimension -6 <= -5
+    >>> check_index([1, 2], 5)
+    >>> check_index([6, 3], 5)
+    Traceback (most recent call last):
+    ...
+    IndexError: Index out of bounds 5
+    >>> check_index(slice(0, 3), 5)
+    """
+    # unknown dimension, assumed to be in bounds
+    if np.isnan(dimension):
+        return
+    elif isinstance(ind, (list, np.ndarray)):
+        x = np.asanyarray(ind)
+        if (x >= dimension).any() or (x < -dimension).any():
+            raise IndexError("Index out of bounds %s" % dimension)
+    elif isinstance(ind, slice):
+        return
+    elif ind is None:
+        return
+
+    elif ind >= dimension:
+        raise IndexError("Index is not smaller than dimension %d >= %d" %
+                         (ind, dimension))
+
+    elif ind < -dimension:
+        msg = "Negative index is not greater than negative dimension %d <= -%d"
+        raise IndexError(msg % (ind, dimension))
+
+
+def sanitize_index(ind):
+    """ Sanitize the elements for indexing along one axis
+    >>> sanitize_index([2, 3, 5])
+    array([2, 3, 5])
+    >>> sanitize_index([True, False, True, False])
+    array([0, 2])
+    >>> sanitize_index(np.array([1, 2, 3]))
+    array([1, 2, 3])
+    >>> sanitize_index(np.array([False, True, True]))
+    array([1, 2])
+    >>> type(sanitize_index(np.int32(0)))
+    <type 'int'>
+    >>> sanitize_index(1.0)
+    1
+    >>> sanitize_index(0.5)
+    Traceback (most recent call last):
+    ...
+    IndexError: Bad index.  Must be integer-like: 0.5
+    """
+    if ind is None:
+        return None
+    elif isinstance(ind, slice):
+        return slice(_sanitize_index_element(ind.start),
+                     _sanitize_index_element(ind.stop),
+                     _sanitize_index_element(ind.step))
+    elif isinstance(ind, Number):
+        return _sanitize_index_element(ind)
+    index_array = np.asanyarray(ind)
+    if index_array.dtype == bool:
+        nonzero = np.nonzero(index_array)
+        if len(nonzero) == 1:
+            # If a 1-element tuple, unwrap the element
+            nonzero = nonzero[0]
+        return np.asanyarray(nonzero)
+    elif np.issubdtype(index_array.dtype, np.integer):
+        return index_array
+    elif np.issubdtype(index_array.dtype, float):
+        int_index = index_array.astype(np.intp)
+        if np.allclose(index_array, int_index):
+            return int_index
+        else:
+            check_int = np.isclose(index_array, int_index)
+            first_err = index_array.ravel(
+            )[np.flatnonzero(~check_int)[0]]
+            raise IndexError("Bad index.  Must be integer-like: %s" %
+                             first_err)
+    else:
+        raise TypeError("Invalid index type", type(ind), ind)
+
+
+def _sanitize_index_element(ind):
+    """Sanitize a one-element index."""
+    if isinstance(ind, Number):
+        ind2 = int(ind)
+        if ind2 != ind:
+            raise IndexError("Bad index.  Must be integer-like: %s" % ind)
+        else:
+            return ind2
+    elif ind is None:
+        return None
+    else:
+        raise TypeError("Invalid index type", type(ind), ind)
+
+
+def normalize_slice(idx, dim):
+    """ Normalize slices to canonical form
+    Parameters
+    ----------
+    idx: slice or other index
+    dim: dimension length
+    Examples
+    --------
+    >>> normalize_slice(slice(0, 10, 1), 10)
+    slice(None, None, None)
+    """
+
+    if isinstance(idx, slice):
+        start, stop, step = idx.start, idx.stop, idx.step
+        if start is not None:
+            if start < 0 and not math.isnan(dim):
+                start = max(0, start + dim)
+            elif start > dim:
+                start = dim
+        if stop is not None:
+            if stop < 0 and not math.isnan(dim):
+                stop = max(0, stop + dim)
+            elif stop > dim:
+                stop = dim
+
+        step = 1 if step is None else step
+
+        if step > 0:
+            if start == 0:
+                start = None
+            if stop == dim:
+                stop = None
+        else:
+            if start == dim - 1:
+                start = None
+            if stop == -1:
+                stop = None
+
+        if step == 1:
+            step = None
+        return slice(start, stop, step)
+    return idx
+
+
+def posify_index(shape, ind):
+    """ Flip negative indices around to positive ones
+    >>> posify_index(10, 3)
+    3
+    >>> posify_index(10, -3)
+    7
+    >>> posify_index(10, [3, -3])
+    array([3, 7])
+    >>> posify_index((10, 20), (3, -3))
+    (3, 17)
+    >>> posify_index((10, 20), (3, [3, 4, -3]))  # doctest: +NORMALIZE_WHITESPACE
+    (3, array([ 3,  4, 17]))
+    """
+    if isinstance(ind, tuple):
+        return tuple(map(posify_index, shape, ind))
+    if isinstance(ind, Integral):
+        if ind < 0 and not math.isnan(shape):
+            return ind + shape
+        else:
+            return ind
+    if isinstance(ind, (np.ndarray, list)) and not math.isnan(shape):
+        ind = np.asanyarray(ind)
+        return np.where(ind < 0, ind + shape, ind)
+
+    return ind

--- a/sparse/slicing.py
+++ b/sparse/slicing.py
@@ -109,8 +109,12 @@ def check_index(ind, dimension):
         return
     elif isinstance(ind, (list, np.ndarray)):
         x = np.asanyarray(ind)
-        if (x >= dimension).any() or (x < -dimension).any():
+        if np.issubdtype(x.dtype, np.integer) and \
+                ((x >= dimension).any() or (x < -dimension).any()):
             raise IndexError("Index out of bounds %s" % dimension)
+        elif x.dtype == bool and len(x) != dimension:
+            raise IndexError("boolean index did not match indexed array; dimension is %s "
+                             "but corresponding boolean dimension is %s", (dimension, len(x)))
     elif isinstance(ind, slice):
         return
     elif ind is None:

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -384,6 +384,8 @@ def test_gt():
     (slice(2, 0, -1), slice(None, None), -1),
     (slice(-2, None, None),),
     (slice(-1, None, None), slice(-2, None, None)),
+    ([True, False], slice(1, None), slice(-2, None)),
+    (slice(1, None), slice(-2, None), [True, False, True, False]),
 ])
 def test_slicing(index):
     x = random_x((2, 3, 4))
@@ -417,6 +419,7 @@ def test_custom_dtype_slicing():
     5,
     -5,
     'foo',
+    ([True, False, False]),
 ])
 def test_slicing_errors(index):
     x = random_x((2, 3, 4))

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -732,13 +732,15 @@ def test_scalar_slicing():
     assert np.isscalar(s[0])
     assert_eq(x[0], s[0])
 
-    assert not np.isscalar(s[0, ...])
+    assert isinstance(s[0, ...], COO)
+    assert s[0, ...].shape == ()
     assert_eq(x[0, ...], s[0, ...])
 
     assert np.isscalar(s[1])
     assert_eq(x[1], s[1])
 
-    assert not np.isscalar(s[1, ...])
+    assert isinstance(s[1, ...], COO)
+    assert s[1, ...].shape == ()
     assert_eq(x[1, ...], s[1, ...])
 
 

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -382,6 +382,8 @@ def test_gt():
     (slice(1, 2, -1), slice(None, None), -1),
     (slice(1, 2, None), slice(None, None, -1), 2),
     (slice(2, 0, -1), slice(None, None), -1),
+    (slice(-2, None, None),),
+    (slice(-1, None, None), slice(-2, None, None)),
 ])
 def test_slicing(index):
     x = random_x((2, 3, 4))

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -408,17 +408,6 @@ def test_custom_dtype_slicing():
     assert_eq(x['part3'], s['part3'])
 
 
-def test_scalar_slicing():
-    x = random_x((2, 3, 4))
-    s = COO.from_numpy(x)
-
-    assert np.isscalar(s[1, 1, 1])
-    assert s[1, 1, 1] == x[1, 1, 1]
-
-    assert not np.isscalar(s[1, 1, 1, ...])
-    assert_eq(s[1, 1, 1, ...], x[1, 1, 1, ...])
-
-
 @pytest.mark.parametrize('index', [
     (Ellipsis, Ellipsis),
     (1, 1, 1, 1),
@@ -740,8 +729,17 @@ def test_caching():
 def test_scalar_slicing():
     x = np.array([0, 1])
     s = COO(x)
+    assert np.isscalar(s[0])
     assert_eq(x[0], s[0])
+
+    assert not np.isscalar(s[0, ...])
+    assert_eq(x[0, ...], s[0, ...])
+
+    assert np.isscalar(s[1])
     assert_eq(x[1], s[1])
+
+    assert not np.isscalar(s[1, ...])
+    assert_eq(x[1, ...], s[1, ...])
 
 
 @pytest.mark.parametrize('shape, k', [

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -396,7 +396,7 @@ def test_custom_dtype_slicing():
                    ('part3', np.int_, (2, 2))])
 
     x = np.zeros((2, 3, 4), dtype=dt)
-    x[1, 1, 1] = (0.64, [4, 2], [[1, 2], [3, 4]])
+    x[1, 1, 1] = (0.64, [4, 2], [[1, 2], [3, 0]])
 
     s = COO.from_numpy(x)
 


### PR DESCRIPTION
Adds support for:

- Returning scalars when slicing, e.g. `x[1, 1]` if `x` is 2-D is now scalar.
- Returning arrays when the last index is an `Ellipsis`, e.g. `x[1, 1, ...]` if `x` is 2-D is now a `()`-shaped `COO` object.
- Slices with steps other than `None` and `1` (even negative steps).
- Inbdexing with custom `dtype`s. So if `x` has a custom `dtype`, `x['field']` is now supported.
- Now throws `IndexError`s consistent with Numpy for string and out of range indices.