### PR TITLE
Out-of-place sort_indices and sum_duplicates

### DIFF
--- a/sparse/core.py
+++ b/sparse/core.py
@@ -4,6 +4,7 @@ from collections import Iterable, defaultdict, deque
 from functools import reduce
 import numbers
 import operator
+import copy
 
 import numpy as np
 import scipy.sparse
@@ -553,6 +554,8 @@ class COO(object):
         return csc
 
     def sort_indices(self):
+        """ Sort indices inplace
+        """
         if self.sorted:
             return
 
@@ -567,7 +570,18 @@ class COO(object):
         self.data = self.data[order]
         self.sorted = True
 
+    def sorted_indices(self):
+        """ Return a new :code:`COO` array with sorted indices. If indices
+        were already sorted, a shallow copy with views on the original data and
+        coordinates is returned.
+        """
+        out = copy.copy(self)
+        out.sort_indices()
+        return out
+
     def sum_duplicates(self):
+        """ Sum duplicates inplace
+        """
         # Inspired by scipy/sparse/coo.py::sum_duplicates
         # See https://github.com/scipy/scipy/blob/master/LICENSE.txt
         if not self.has_duplicates:
@@ -593,6 +607,15 @@ class COO(object):
         self.data = data
         self.coords = coords
         self.has_duplicates = False
+
+    def summed_duplicates(self):
+        """ Return a new :code:`COO` array with summed dupicates. If there were
+        no duplicates, a shallow copy with views on the original data and
+        coordinates is returned.
+        """
+        out = copy.copy(self)
+        out.sum_duplicates()
+        return out
 
     def __add__(self, other):
         return self.elemwise(operator.add, other)

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -560,21 +560,20 @@ class COO(object):
 
         if (np.diff(linear) > 0).all():  # already sorted
             self.sorted = True
-            return self
+            return
 
         order = np.argsort(linear)
         self.coords = self.coords[:, order]
         self.data = self.data[order]
         self.sorted = True
-        return self
 
     def sum_duplicates(self):
         # Inspired by scipy/sparse/coo.py::sum_duplicates
         # See https://github.com/scipy/scipy/blob/master/LICENSE.txt
         if not self.has_duplicates:
-            return self
+            return
         if not np.prod(self.coords.shape):
-            return self
+            return
 
         self.sort_indices()
 
@@ -583,7 +582,7 @@ class COO(object):
 
         if unique_mask.sum() == len(unique_mask):  # already unique
             self.has_duplicates = False
-            return self
+            return
 
         unique_mask = np.append(True, unique_mask)
 
@@ -594,8 +593,6 @@ class COO(object):
         self.data = data
         self.coords = coords
         self.has_duplicates = False
-
-        return self
 
     def __add__(self, other):
         return self.elemwise(operator.add, other)


### PR DESCRIPTION
As far as I can tell `COO.sort_indices()` and `COO.sum_duplicates()` are the only two functions that specifically modify the array inplace (and in some cases also needlessly `return self`).

However, specifically for `sort_indices()` an out-of-place counterpart would be very interesting, e.g. when comparing two `COO` arrays: Temporarily sort both, then compare `.coords` and `.data` to see if they are equal.

Having both an inplace and an out-of-place function for the same operation is like Python offering `sorted(mylist)` and `mylist.sort()`.

What do you think?