### PR TITLE
flake8 and coverage in pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,10 @@ install:
   - conda create -n test-sparse python=$TRAVIS_PYTHON_VERSION pytest numpy scipy flake8 nomkl
   - source activate test-sparse
 
-  - python setup.py install
+  - pip install -e .[tests]
 
 script:
-  - py.test --doctest-modules sparse
-  - flake8 sparse
+  - py.test
 
 notifications:
   email: false

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ ignore =
     # visually indented line with same indent as next logical line
     E129,
     # unexpected indentation
-    E116 
+    E116
 
 max-line-length = 120
 
@@ -47,3 +47,6 @@ parentdir_prefix = distributed-
 
 [bdist_wheel]
 universal=1
+
+[tool:pytest]
+addopts = --flake8 --doctest-modules sparse --cov-report term-missing --cov sparse

--- a/setup.py
+++ b/setup.py
@@ -16,4 +16,11 @@ setup(name='sparse',
       long_description=(open('README.rst').read() if exists('README.rst')
                         else ''),
       install_requires=list(open('requirements.txt').read().strip().split('\n')),
+      extras_require={
+          'tests': [
+              'pytest',
+              'pytest-cov',
+              'pytest-flake8',
+          ],
+      },
       zip_safe=False)


### PR DESCRIPTION
I totally missed that you guys were using `flake8` to keep the code style clean... To make it easier for first time contributors we could, instead of running `flake8` manually, integrate it into the `pytest` run.