### PR TITLE
Validate .transpose() axes

### DIFF
--- a/sparse/core.py
+++ b/sparse/core.py
@@ -425,6 +425,18 @@ class COO(object):
         if axes is None:
             axes = reversed(range(self.ndim))
 
+        # Normalize all axe indices to posivite values
+        try:
+            axes = np.arange(self.ndim)[list(axes)]
+        except IndexError as e:
+            raise ValueError("invalid axis for this array") from None
+
+        if len(np.unique(axes)) < len(axes):
+            raise ValueError("repeated axis in transpose")
+
+        if not len(axes) == self.ndim:
+            raise ValueError("axes don't match array")
+
         axes = tuple(axes)
 
         if axes == tuple(range(self.ndim)):

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -429,7 +429,7 @@ class COO(object):
         try:
             axes = np.arange(self.ndim)[list(axes)]
         except IndexError as e:
-            raise ValueError("invalid axis for this array") from None
+            raise ValueError("invalid axis for this array")
 
         if len(np.unique(axes)) < len(axes):
             raise ValueError("repeated axis in transpose")

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -428,7 +428,7 @@ class COO(object):
         # Normalize all axe indices to posivite values
         try:
             axes = np.arange(self.ndim)[list(axes)]
-        except IndexError as e:
+        except IndexError:
             raise ValueError("invalid axis for this array")
 
         if len(np.unique(axes)) < len(axes):

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -44,13 +44,39 @@ def test_ufunc_reductions(reduction, axis, keepdims, kwargs, eqkwargs):
     assert_eq(xx, yy, **eqkwargs)
 
 
-@pytest.mark.parametrize('axis', [None, (1, 2, 0), (2, 1, 0), (0, 1, 2)])
+@pytest.mark.parametrize('axis', [
+    None,
+    (1, 2, 0),
+    (2, 1, 0),
+    (0, 1, 2),
+    (0, 1, -1),
+    (0, -2, -1),
+    (-3, -2, -1),
+])
 def test_transpose(axis):
     x = sparse.random((2, 3, 4), density=.25)
     y = x.todense()
     xx = x.transpose(axis)
     yy = y.transpose(axis)
     assert_eq(xx, yy)
+
+
+@pytest.mark.parametrize('axis', [
+    (0, 1),  # too few
+    (0, 1, 2, 3),  # too many
+    (3, 1, 0),  # axis 3 illegal
+    (0, -1, -4),  # axis -4 illegal
+    (0, 0, 1),  # duplicate axis 0
+    (0, -1, 2),  # duplicate axis -1 == 2
+])
+def test_transpose_error(axis):
+    x = sparse.random((2, 3, 4), density=.25)
+    y = x.todense()
+
+    with pytest.raises(ValueError):
+        x.transpose(axis)
+    with pytest.raises(ValueError):
+        y.transpose(axis)
 
 
 @pytest.mark.parametrize('a,b', [


### PR DESCRIPTION
Before this change `COO` arrays allowed many variants of illegal `.transpose()` parameters:

    sparse.random((2, 3, 4)).transpose((0, 0, 1))  # duplicate axis
    sparse.random((2, 3, 4)).transpose((0, 1))  # too few
    sparse.random((2, 3, 4)).transpose((0, 1, 2, 3))  # too many

This PR adds some sanity checks and compares the exceptions of some scenarios with the exceptions from NumPy.