### PR TITLE
Use higher density for sparse.random in tests

### DIFF
--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -92,7 +92,7 @@ def test_transpose_error(axis):
     [(), ()],
 ])
 def test_reshape(a, b):
-    s = sparse.random(a)
+    s = sparse.random(a, density=0.5)
     x = s.todense()
 
     assert_eq(x.reshape(b), s.reshape(b))
@@ -111,13 +111,13 @@ def test_large_reshape():
 
 
 def test_reshape_same():
-    s = sparse.random((3, 5))
+    s = sparse.random((3, 5), density=0.5)
 
     assert s.reshape(s.shape) is s
 
 
 def test_to_scipy_sparse():
-    s = sparse.random((3, 5))
+    s = sparse.random((3, 5), density=0.5)
     a = s.to_scipy_sparse()
     b = scipy.sparse.coo_matrix(s.todense())
 
@@ -138,8 +138,8 @@ def test_to_scipy_sparse():
     [(4,), (4,), 0],
 ])
 def test_tensordot(a_shape, b_shape, axes):
-    sa = sparse.random(a_shape)
-    sb = sparse.random(b_shape)
+    sa = sparse.random(a_shape, density=0.5)
+    sb = sparse.random(b_shape, density=0.5)
 
     a = sa.todense()
     b = sb.todense()
@@ -160,8 +160,8 @@ def test_tensordot(a_shape, b_shape, axes):
 
 def test_dot():
     import operator
-    sa = sparse.random((3, 4, 5))
-    sb = sparse.random((5, 6))
+    sa = sparse.random((3, 4, 5), density=0.5)
+    sb = sparse.random((5, 6), density=0.5)
 
     a = sa.todense()
     b = sb.todense()
@@ -181,8 +181,8 @@ def test_dot():
 
 @pytest.mark.xfail
 def test_dot_nocoercion():
-    sa = sparse.random((3, 4, 5))
-    sb = sparse.random((5, 6))
+    sa = sparse.random((3, 4, 5), density=0.5)
+    sb = sparse.random((5, 6), density=0.5)
 
     a = sa.todense()
     b = sb.todense()
@@ -203,7 +203,7 @@ def test_dot_nocoercion():
                                   lambda x: x.astype('int32'), np.conjugate,
                                   np.conj, lambda x: x.round(decimals=2), abs])
 def test_elemwise(func):
-    s = sparse.random((2, 3, 4))
+    s = sparse.random((2, 3, 4), density=0.5)
     x = s.todense()
 
     fs = func(s)
@@ -219,8 +219,8 @@ def test_elemwise(func):
 ])
 @pytest.mark.parametrize('shape', [(2,), (2, 3), (2, 3, 4), (2, 3, 4, 5)])
 def test_elemwise_binary(func, shape):
-    xs = sparse.random(shape)
-    ys = sparse.random(shape)
+    xs = sparse.random(shape, density=0.5)
+    ys = sparse.random(shape, density=0.5)
 
     x = xs.todense()
     y = ys.todense()
@@ -235,16 +235,16 @@ def test_elemwise_binary(func, shape):
 @pytest.mark.filterwarnings('ignore:divide by zero')
 @pytest.mark.filterwarnings('ignore:invalid value')
 def test_auto_densification_fails(func):
-    xs = sparse.random((2, 3, 4))
-    ys = sparse.random((2, 3, 4))
+    xs = sparse.random((2, 3, 4), density=0.5)
+    ys = sparse.random((2, 3, 4), density=0.5)
 
     with pytest.raises(ValueError):
         func(xs, ys)
 
 
 def test_op_scipy_sparse():
-    xs = sparse.random((3, 4))
-    y = sparse.random((3, 4)).todense()
+    xs = sparse.random((3, 4), density=0.5)
+    y = sparse.random((3, 4), density=0.5).todense()
 
     ys = scipy.sparse.csr_matrix(y)
     x = xs.todense()
@@ -267,7 +267,7 @@ def test_op_scipy_sparse():
     (operator.eq, 1)
 ])
 def test_elemwise_scalar(func, scalar):
-    xs = sparse.random((2, 3, 4))
+    xs = sparse.random((2, 3, 4), density=0.5)
     y = scalar
 
     x = xs.todense()
@@ -295,7 +295,7 @@ def test_elemwise_scalar(func, scalar):
 @pytest.mark.filterwarnings('ignore:divide by zero')
 @pytest.mark.filterwarnings('ignore:invalid value')
 def test_scalar_densification_fails(func, scalar):
-    xs = sparse.random((2, 3, 4))
+    xs = sparse.random((2, 3, 4), density=0.5)
     y = scalar
 
     with pytest.raises(ValueError):
@@ -331,7 +331,7 @@ def test_bitwise_binary_bool(func, shape):
 
 def test_elemwise_binary_empty():
     x = COO({}, shape=(10, 10))
-    y = sparse.random((10, 10))
+    y = sparse.random((10, 10), density=0.5)
 
     for z in [x * y, y * x]:
         assert z.nnz == 0
@@ -399,7 +399,7 @@ def test_gt():
     (slice(1, None), slice(-2, None), [True, False, True, False]),
 ])
 def test_slicing(index):
-    s = sparse.random((2, 3, 4))
+    s = sparse.random((2, 3, 4), density=0.5)
     x = s.todense()
 
     assert_eq(x[index], s[index])
@@ -433,7 +433,7 @@ def test_custom_dtype_slicing():
     ([True, False, False]),
 ])
 def test_slicing_errors(index):
-    s = sparse.random((2, 3, 4))
+    s = sparse.random((2, 3, 4), density=0.5)
     x = s.todense()
 
     try:
@@ -471,21 +471,21 @@ def test_canonical():
 
 
 def test_concatenate():
-    xx = sparse.random((2, 3, 4))
+    xx = sparse.random((2, 3, 4), density=0.5)
     x = xx.todense()
-    yy = sparse.random((5, 3, 4))
+    yy = sparse.random((5, 3, 4), density=0.5)
     y = yy.todense()
-    zz = sparse.random((4, 3, 4))
+    zz = sparse.random((4, 3, 4), density=0.5)
     z = zz.todense()
 
     assert_eq(np.concatenate([x, y, z], axis=0),
               sparse.concatenate([xx, yy, zz], axis=0))
 
-    xx = sparse.random((5, 3, 1))
+    xx = sparse.random((5, 3, 1), density=0.5)
     x = xx.todense()
-    yy = sparse.random((5, 3, 3))
+    yy = sparse.random((5, 3, 3), density=0.5)
     y = yy.todense()
-    zz = sparse.random((5, 3, 2))
+    zz = sparse.random((5, 3, 2), density=0.5)
     z = zz.todense()
 
     assert_eq(np.concatenate([x, y, z], axis=2),
@@ -498,7 +498,7 @@ def test_concatenate():
 @pytest.mark.parametrize('axis', [0, 1])
 @pytest.mark.parametrize('func', ['stack', 'concatenate'])
 def test_concatenate_mixed(func, axis):
-    s = sparse.random((10, 10))
+    s = sparse.random((10, 10), density=0.5)
     d = s.todense()
 
     result = getattr(sparse, func)([d, s, s], axis=axis)
@@ -512,11 +512,11 @@ def test_concatenate_mixed(func, axis):
 @pytest.mark.parametrize('shape', [(5,), (2, 3, 4), (5, 2)])
 @pytest.mark.parametrize('axis', [0, 1, -1])
 def test_stack(shape, axis):
-    xx = sparse.random(shape)
+    xx = sparse.random(shape, density=0.5)
     x = xx.todense()
-    yy = sparse.random(shape)
+    yy = sparse.random(shape, density=0.5)
     y = yy.todense()
-    zz = sparse.random(shape)
+    zz = sparse.random(shape, density=0.5)
     z = zz.todense()
 
     assert_eq(np.stack([x, y, z], axis=axis),
@@ -538,7 +538,7 @@ def test_large_concat_stack():
 
 
 def test_coord_dtype():
-    s = sparse.random((2, 3, 4))
+    s = sparse.random((2, 3, 4), density=0.5)
     assert s.coords.dtype == np.uint8
 
     s = COO.from_numpy(np.zeros(1000))
@@ -546,10 +546,10 @@ def test_coord_dtype():
 
 
 def test_addition():
-    a = sparse.random((2, 3, 4))
+    a = sparse.random((2, 3, 4), density=0.5)
     x = a.todense()
 
-    b = sparse.random((2, 3, 4))
+    b = sparse.random((2, 3, 4), density=0.5)
     y = b.todense()
 
     assert_eq(x + y, a + b)
@@ -578,10 +578,10 @@ def test_addition_not_ok_when_large_and_sparse():
                                            ((3, 4, 1), (3, 4, 2)),
                                            ((1, 5), (5, 1))])
 def test_broadcasting(func, shape1, shape2):
-    a = sparse.random(shape1)
+    a = sparse.random(shape1, density=0.5)
     x = a.todense()
 
-    c = sparse.random(shape2)
+    c = sparse.random(shape2, density=0.5)
     z = c.todense()
 
     expected = func(x, z)
@@ -596,14 +596,14 @@ def test_broadcasting(func, shape1, shape2):
                                            ((3, 1, 4), (3, 2, 4)),
                                            ((3, 4, 1), (3, 4, 2))])
 def test_broadcast_to(shape1, shape2):
-    a = sparse.random(shape1)
+    a = sparse.random(shape1, density=0.5)
     x = a.todense()
 
     assert_eq(np.broadcast_to(x, shape2), a.broadcast_to(shape2))
 
 
 def test_scalar_multiplication():
-    a = sparse.random((2, 3, 4))
+    a = sparse.random((2, 3, 4), density=0.5)
     x = a.todense()
 
     assert_eq(x * 2, a * 2)
@@ -615,7 +615,7 @@ def test_scalar_multiplication():
 
 @pytest.mark.filterwarnings('ignore:divide by zero')
 def test_scalar_exponentiation():
-    a = sparse.random((2, 3, 4))
+    a = sparse.random((2, 3, 4), density=0.5)
     x = a.todense()
 
     assert_eq(x ** 2, a ** 2)
@@ -671,7 +671,7 @@ def test_scipy_sparse_interface():
 
 
 def test_cache_csr():
-    x = sparse.random((10, 5)).todense()
+    x = sparse.random((10, 5), density=0.5).todense()
     s = COO(x, cache=True)
 
     assert isinstance(s.tocsr(), scipy.sparse.csr_matrix)
@@ -765,7 +765,7 @@ def test_scalar_slicing():
     ((4, 4), 1000),
 ])
 def test_triul(shape, k):
-    s = sparse.random(shape)
+    s = sparse.random(shape, density=0.5)
     x = s.todense()
 
     assert_eq(np.triu(x, k), sparse.triu(s, k))

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -121,8 +121,9 @@ def test_to_scipy_sparse():
     a = s.to_scipy_sparse()
     b = scipy.sparse.coo_matrix(s.todense())
 
-    assert_eq(a.data, b.data)
     assert_eq(a.todense(), b.todense())
+    assert_eq(a.data[np.lexsort((a.row, a.col))],
+              b.data[np.lexsort((b.row, b.col))])
 
 
 @pytest.mark.parametrize('a_shape,b_shape,axes', [

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -121,9 +121,7 @@ def test_to_scipy_sparse():
     a = s.to_scipy_sparse()
     b = scipy.sparse.coo_matrix(s.todense())
 
-    assert_eq(a.todense(), b.todense())
-    assert_eq(a.data[np.lexsort((a.row, a.col))],
-              b.data[np.lexsort((b.row, b.col))])
+    assert_eq(a, b)
 
 
 @pytest.mark.parametrize('a_shape,b_shape,axes', [


### PR DESCRIPTION
Fixes #63.

Actually, one test fails with a higher density.