### PR TITLE
Support left-side np.number elemwise operations.

### DIFF
--- a/sparse/core.py
+++ b/sparse/core.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from collections import Iterable, defaultdict, deque
-from functools import reduce
+from functools import reduce, partial
 import numbers
 import operator
 
@@ -728,8 +728,13 @@ class COO(object):
         self = args[0]
         if isinstance(self, scipy.sparse.spmatrix):
             self = COO.from_numpy(self)
-        if isinstance(self, np.number):
-            self = COO.from_numpy(np.atleast_1d(self))
+        elif np.isscalar(self) or (isinstance(self, np.ndarray)
+                                   and self.ndim == 0):
+            func = partial(func, self)
+            other = args[1]
+            if isinstance(other, scipy.sparse.spmatrix):
+                other = COO.from_numpy(other)
+            return other._elemwise_unary(func, *args[2:], **kwargs)
 
         if len(args) == 1:
             return self._elemwise_unary(func, *args[1:], **kwargs)

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -728,6 +728,8 @@ class COO(object):
         self = args[0]
         if isinstance(self, scipy.sparse.spmatrix):
             self = COO.from_numpy(self)
+        if isinstance(self, np.number):
+            self = COO.from_numpy(np.atleast_1d(self))
 
         if len(args) == 1:
             return self._elemwise_unary(func, *args[1:], **kwargs)

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -266,8 +266,11 @@ def test_op_scipy_sparse():
     (operator.le, -3),
     (operator.eq, 1)
 ])
-def test_elemwise_scalar(func, scalar):
+@pytest.mark.parametrize('convert_to_np_number', [True, False])
+def test_elemwise_scalar(func, scalar, convert_to_np_number):
     xs = sparse.random((2, 3, 4))
+    if convert_to_np_number:
+        scalar = np.float32(scalar)
     y = scalar
 
     x = xs.todense()
@@ -277,6 +280,33 @@ def test_elemwise_scalar(func, scalar):
     assert xs.nnz >= fs.nnz
 
     assert_eq(fs, func(x, y))
+
+
+@pytest.mark.parametrize('func, scalar', [
+    (operator.mul, 5),
+    (operator.add, 0),
+    (operator.sub, 0),
+    (operator.gt, -5),
+    (operator.lt, 5),
+    (operator.ne, 0),
+    (operator.ge, -5),
+    (operator.le, 3),
+    (operator.eq, 1)
+])
+@pytest.mark.parametrize('convert_to_np_number', [True, False])
+def test_leftside_elemwise_scalar(func, scalar, convert_to_np_number):
+    xs = sparse.random((2, 3, 4), density=0.5)
+    if convert_to_np_number:
+        scalar = np.float32(scalar)
+    y = scalar
+
+    x = xs.todense()
+    fs = func(y, xs)
+
+    assert isinstance(fs, COO)
+    assert xs.nnz >= fs.nnz
+
+    assert_eq(fs, func(y, x))
 
 
 @pytest.mark.parametrize('func, scalar', [
@@ -602,8 +632,7 @@ def test_broadcast_to(shape1, shape2):
     assert_eq(np.broadcast_to(x, shape2), a.broadcast_to(shape2))
 
 
-@pytest.mark.parametrize('scalar', [2, 2.0, 2.5, np.float32(2.0),
-                                    np.float(2.0)])
+@pytest.mark.parametrize('scalar', [2, 2.5, np.float32(2.0), np.int8(3)])
 def test_scalar_multiplication(scalar):
     a = sparse.random((2, 3, 4), density=0.5)
     x = a.todense()

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -605,7 +605,7 @@ def test_broadcast_to(shape1, shape2):
 @pytest.mark.parametrize('scalar', [2, 2.0, 2.5, np.float32(2.0),
                                     np.float(2.0)])
 def test_scalar_multiplication(scalar):
-    a = sparse.random((2, 3, 4))
+    a = sparse.random((2, 3, 4), density=0.5)
     x = a.todense()
 
     assert_eq(x * scalar, a * scalar)

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -602,15 +602,16 @@ def test_broadcast_to(shape1, shape2):
     assert_eq(np.broadcast_to(x, shape2), a.broadcast_to(shape2))
 
 
-def test_scalar_multiplication():
+@pytest.mark.parametrize('scalar', [2, 2.0, 2.5, np.float32(2.0),
+                                    np.float(2.0)])
+def test_scalar_multiplication(scalar):
     a = sparse.random((2, 3, 4))
     x = a.todense()
 
-    assert_eq(x * 2, a * 2)
-    assert_eq(2 * x, 2 * a)
-    assert_eq(x / 2, a / 2)
-    assert_eq(x / 2.5, a / 2.5)
-    assert_eq(x // 2.5, a // 2.5)
+    assert_eq(x * scalar, a * scalar)
+    assert_eq(scalar * x, scalar * a)
+    assert_eq(x / scalar, a / scalar)
+    assert_eq(x // scalar, a // scalar)
 
 
 @pytest.mark.filterwarnings('ignore:divide by zero')

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -609,9 +609,13 @@ def test_scalar_multiplication(scalar):
     x = a.todense()
 
     assert_eq(x * scalar, a * scalar)
+    assert (a * scalar).nnz == a.nnz
     assert_eq(scalar * x, scalar * a)
+    assert (scalar * a).nnz == a.nnz
     assert_eq(x / scalar, a / scalar)
+    assert (a / scalar).nnz == a.nnz
     assert_eq(x // scalar, a // scalar)
+    # division may reduce nnz.
 
 
 @pytest.mark.filterwarnings('ignore:divide by zero')


### PR DESCRIPTION
Fixes #66.

This adds a workaround when the np.number multiplication from left-side.