### PR TITLE
len() function for COO objects

### DIFF
--- a/sparse/core.py
+++ b/sparse/core.py
@@ -269,7 +269,7 @@ class COO(object):
 
         Examples
         --------
-        >>> x = np.zeros(10, 10)
+        >>> x = np.zeros((10, 10))
         >>> s = COO.from_numpy(x)
         >>> len(s)
         10

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -253,6 +253,9 @@ class COO(object):
     def nbytes(self):
         return self.data.nbytes + self.coords.nbytes
 
+    def __len__(self):
+        return self.shape[0]
+
     def __sizeof__(self):
         return self.nbytes
 

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -254,6 +254,26 @@ class COO(object):
         return self.data.nbytes + self.coords.nbytes
 
     def __len__(self):
+        """
+        Get "length" of array, which is by definition the size of the first
+        dimension.
+
+        Returns
+        -------
+        int
+            The size of the first dimension.
+
+        See Also
+        --------
+        numpy.ndarray.__len__ : Numpy equivalent property.
+
+        Examples
+        --------
+        >>> x = np.zeros(10, 10)
+        >>> s = COO.from_numpy(x)
+        >>> len(s)
+        10
+        """
         return self.shape[0]
 
     def __sizeof__(self):

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -875,3 +875,8 @@ def test_scalar_shape_construction():
     s = COO(coords, x, shape=5)
 
     assert_eq(x, s)
+
+
+def test_len():
+    s = sparse.random((20, 30, 40))
+    assert len(s) == 20


### PR DESCRIPTION
Quite trivial really, implements the `len()` operation following NumPy's convention of

    len(array) == array.shape[0]