### PR TITLE
Size and density properties

### DIFF
--- a/docs/generated/sparse.COO.density.rst
+++ b/docs/generated/sparse.COO.density.rst
@@ -1,0 +1,6 @@
+COO\.density
+============
+
+.. currentmodule:: sparse
+
+.. autoattribute:: COO.density

--- a/docs/generated/sparse.COO.rst
+++ b/docs/generated/sparse.COO.rst
@@ -18,6 +18,8 @@ COO
       COO.nbytes
       COO.ndim
       COO.nnz
+      COO.size
+      COO.density
 
    .. rubric:: :doc:`Constructing COO objects <../user_manual/constructing>`
    .. autosummary::

--- a/docs/generated/sparse.COO.size.rst
+++ b/docs/generated/sparse.COO.size.rst
@@ -1,0 +1,6 @@
+COO\.size
+=========
+
+.. currentmodule:: sparse
+
+.. autoattribute:: COO.size

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -551,11 +551,11 @@ class COO(object):
 
         Examples
         --------
-        >>> x = np.zeros((10, 10))
+        >>> x = np.zeros((8, 8))
         >>> x[0, :] = 1
         >>> s = COO.from_numpy(x)
         >>> s.density
-        0.10000000000000001
+        0.125
         """
         return self.nnz / self.size
 

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -511,6 +511,14 @@ class COO(object):
         """
         return self.shape[0]
 
+    @property
+    def size(self):
+        return np.prod(self.shape)
+
+    @property
+    def density(self):
+        return self.nnz / self.size
+
     def __sizeof__(self):
         return self.nbytes
 

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -237,7 +237,7 @@ class COO(object):
         if self.coords.ndim == 1:
             self.coords = self.coords[None, :]
 
-        if shape and not np.prod(self.coords.shape):
+        if shape and not self.coords.size:
             self.coords = np.zeros((len(shape), 0), dtype=np.uint64)
 
         if shape is None:
@@ -748,7 +748,7 @@ class COO(object):
 
         if set(axis) == set(range(self.ndim)):
             result = method.reduce(self.data, **kwargs)
-            if self.nnz != np.prod(self.shape):
+            if self.nnz != self.size:
                 result = method(result, _zero_of_dtype(self.dtype)[()], **kwargs)
         else:
             axis = tuple(axis)
@@ -1277,7 +1277,7 @@ class COO(object):
         if self.shape == shape:
             return self
         if any(d == -1 for d in shape):
-            extra = int(np.prod(self.shape) /
+            extra = int(self.size /
                         np.prod([d for d in shape if d != -1]))
             shape = tuple([d if d != -1 else extra for d in shape])
 
@@ -1289,7 +1289,7 @@ class COO(object):
                 if sh == shape:
                     return value
 
-        # TODO: this np.prod(self.shape) enforces a 2**64 limit to array size
+        # TODO: this self.size enforces a 2**64 limit to array size
         linear_loc = self.linear_loc()
 
         max_shape = max(shape) if len(shape) != 0 else 1
@@ -1480,7 +1480,7 @@ class COO(object):
         # See https://github.com/scipy/scipy/blob/master/LICENSE.txt
         if not self.has_duplicates:
             return
-        if not np.prod(self.coords.shape):
+        if not self.coords.size:
             return
 
         self.sort_indices()
@@ -2029,9 +2029,7 @@ class COO(object):
             ...
         NotImplementedError: Operation would require converting large sparse array to dense
         """
-        elements = np.prod(self.shape)
-
-        if elements <= allowed_nnz or self.nnz >= elements * allowed_fraction:
+        if self.size <= allowed_nnz or self.density >= allowed_fraction:
             return self.todense()
         else:
             raise NotImplementedError("Operation would require converting "

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -513,10 +513,50 @@ class COO(object):
 
     @property
     def size(self):
+        """
+        The number of all elements (including zeros) in this array.
+
+        Returns
+        -------
+        int
+            The number of elements.
+
+        See Also
+        --------
+        numpy.ndarray.size : Numpy equivalent property.
+
+        Examples
+        --------
+        >>> x = np.zeros(10, 10)
+        >>> s = COO.from_numpy(x)
+        >>> s.size
+        100
+        """
         return np.prod(self.shape)
 
     @property
     def density(self):
+        """
+        The ratio of nonzero to all elements in this array.
+
+        Returns
+        -------
+        float
+            The ratio of nonzero to all elements.
+
+        See Also
+        --------
+        COO.size : Number of elements.
+        COO.nnz : Number of nonzero elements.
+
+        Examples
+        --------
+        >>> x = np.zeros(10, 10)
+        >>> x[0, :] = 1
+        >>> s = COO.from_numpy(x)
+        >>> s.density
+        0.10000000000000001
+        """
         return self.nnz / self.size
 
     def __sizeof__(self):

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -2005,7 +2005,7 @@ class COO(object):
 
         Raises
         -------
-        NotImplementedError
+        ValueError
             If the returned array would be too large.
 
         Examples

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -1986,17 +1986,17 @@ class COO(object):
         assert out is None
         return self.elemwise(np.ndarray.astype, dtype)
 
-    def maybe_densify(self, allowed_nnz=1000, allowed_fraction=0.25):
+    def maybe_densify(self, max_size=1000, min_fraction=0.25):
         """
         Converts this :obj:`COO` array to a :obj:`numpy.ndarray` if not too
         costly.
 
         Parameters
         ----------
-        allowed_nnz : int
-            Allowed number of nonzero values
-        allowed_fraction : float
-            Allowed density of nonzero values
+        max_size : int
+            Maximum number of elements in output
+        min_fraction : float
+            Minimum density of output
 
         Returns
         -------
@@ -2017,19 +2017,19 @@ class COO(object):
         >>> np.allclose(x, s.todense())
         True
 
-        You can also specify the minimum allowed sparsity or the maximum number
-        of nonzero values. If both conditions are unmet, this method will throw
+        You can also specify the minimum allowed density or the maximum number
+        of output elements. If both conditions are unmet, this method will throw
         an error.
 
         >>> x = np.zeros((5, 5), dtype=np.uint8)
         >>> x[2, 2] = 1
         >>> s = COO.from_numpy(x)
-        >>> s.maybe_densify(allowed_nnz=5, allowed_fraction=0.25)
+        >>> s.maybe_densify(max_size=5, min_fraction=0.25)
         Traceback (most recent call last):
             ...
         NotImplementedError: Operation would require converting large sparse array to dense
         """
-        if self.size <= allowed_nnz or self.density >= allowed_fraction:
+        if self.size <= max_size or self.density >= min_fraction:
             return self.todense()
         else:
             raise ValueError("Operation would require converting "

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -2032,8 +2032,8 @@ class COO(object):
         if self.size <= allowed_nnz or self.density >= allowed_fraction:
             return self.todense()
         else:
-            raise NotImplementedError("Operation would require converting "
-                                      "large sparse array to dense")
+            raise ValueError("Operation would require converting "
+                             "large sparse array to dense")
 
 
 def tensordot(a, b, axes=2):

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -527,7 +527,7 @@ class COO(object):
 
         Examples
         --------
-        >>> x = np.zeros(10, 10)
+        >>> x = np.zeros((10, 10))
         >>> s = COO.from_numpy(x)
         >>> s.size
         100
@@ -551,7 +551,7 @@ class COO(object):
 
         Examples
         --------
-        >>> x = np.zeros(10, 10)
+        >>> x = np.zeros((10, 10))
         >>> x[0, :] = 1
         >>> s = COO.from_numpy(x)
         >>> s.density

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -2027,7 +2027,7 @@ class COO(object):
         >>> s.maybe_densify(max_size=5, min_density=0.25)
         Traceback (most recent call last):
             ...
-        NotImplementedError: Operation would require converting large sparse array to dense
+        ValueError: Operation would require converting large sparse array to dense
         """
         if self.size <= max_size or self.density >= min_density:
             return self.todense()

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -1986,7 +1986,7 @@ class COO(object):
         assert out is None
         return self.elemwise(np.ndarray.astype, dtype)
 
-    def maybe_densify(self, max_size=1000, min_fraction=0.25):
+    def maybe_densify(self, max_size=1000, min_density=0.25):
         """
         Converts this :obj:`COO` array to a :obj:`numpy.ndarray` if not too
         costly.
@@ -1995,7 +1995,7 @@ class COO(object):
         ----------
         max_size : int
             Maximum number of elements in output
-        min_fraction : float
+        min_density : float
             Minimum density of output
 
         Returns
@@ -2024,12 +2024,12 @@ class COO(object):
         >>> x = np.zeros((5, 5), dtype=np.uint8)
         >>> x[2, 2] = 1
         >>> s = COO.from_numpy(x)
-        >>> s.maybe_densify(max_size=5, min_fraction=0.25)
+        >>> s.maybe_densify(max_size=5, min_density=0.25)
         Traceback (most recent call last):
             ...
         NotImplementedError: Operation would require converting large sparse array to dense
         """
-        if self.size <= max_size or self.density >= min_fraction:
+        if self.size <= max_size or self.density >= min_density:
             return self.todense()
         else:
             raise ValueError("Operation would require converting "

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -1077,7 +1077,7 @@ def test_len():
 
 def test_density():
     s = sparse.random((20, 30, 40), density=0.1)
-    assert 0.09 < s.density < 0.11
+    assert np.isclose(s.density, 0.1)
 
 
 def test_size():

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -1073,3 +1073,13 @@ def test_scalar_shape_construction():
 def test_len():
     s = sparse.random((20, 30, 40))
     assert len(s) == 20
+
+
+def test_density():
+    s = sparse.random((20, 30, 40), density=0.1)
+    assert 0.09 < s.density < 0.11
+
+
+def test_size():
+    s = sparse.random((20, 30, 40))
+    assert s.density == 20 * 30 * 40

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -1082,4 +1082,4 @@ def test_density():
 
 def test_size():
     s = sparse.random((20, 30, 40))
-    assert s.density == 20 * 30 * 40
+    assert s.size == 20 * 30 * 40


### PR DESCRIPTION
NumPy has a `.size` property that gives you the number of elements in an array. 

Additionally for sparse arrays a `.density` property may be handy, which is the ratio of nonzero elements to total elements in the array (a value between `0` and `1`).

This PR implements both properties for `COO` arrays
  