### PR TITLE
Fix test_slicing_errors failing for older NumPy versions

### DIFF
--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -1,5 +1,6 @@
 import pytest
 
+from packaging import version
 import operator
 import numpy as np
 import scipy.sparse
@@ -459,7 +460,13 @@ def test_custom_dtype_slicing():
     5,
     -5,
     'foo',
-    ([True, False, False]),
+    pytest.param(
+        [True, False, False],
+        marks=pytest.mark.skipif(
+            version.parse(np.version.version) < version.parse("1.13.0"),
+            reason="NumPy < 1.13.0 does not raise these Exceptions"
+        )
+    ),
 ])
 def test_slicing_errors(index):
     s = sparse.random((2, 3, 4), density=0.5)


### PR DESCRIPTION
Prior to NumPy `1.13.0`, you would see a `VisibleDeprecationWarning` but no exception when using illegal indexing values. This makes test `test_slicing_errors[index6]` fail.

    __________________________________ test_slicing_errors[index6] ____________________________________

    index = [True, False, False]

        @pytest.mark.parametrize('index', [
            (Ellipsis, Ellipsis),
            (1, 1, 1, 1),
            (slice(None),) * 4,
            5,
            -5,
            'foo',
            ([True, False, False]),
        ])
        def test_slicing_errors(index):
            s = sparse.random((2, 3, 4), density=0.5)
            x = s.todense()

            try:
                x[index]
            except Exception as e:
                e1 = e
            else:
    >           raise Exception("exception not raised")
    E           Exception: exception not raised

    sparse/tests/test_core.py:473: Exception
    ===================================== warnings summary ==============================================
    sparse/tests/test_core.py::test_slicing_errors[index6]
      /Users/nwerner/Arbeit/mdct/sparse/sparse/tests/test_core.py:469: VisibleDeprecationWarning: boolean
      index did not match indexed array along dimension 0; dimension is 2 but corresponding boolean dimension is 3
        x[index]

    -- Docs: http://doc.pytest.org/en/latest/warnings.html

Either the test should be skipped for NumPy < 1.13.0, or we should bump the dependency version.