### PR TITLE
Deal with np.array(sparsearr) densification

### DIFF
--- a/docs/generated/sparse.COO.__array__.rst
+++ b/docs/generated/sparse.COO.__array__.rst
@@ -1,0 +1,6 @@
+COO\.\_\_array\_\_
+==================
+
+.. currentmodule:: sparse
+
+.. automethod:: COO.__array__

--- a/docs/generated/sparse.COO.rst
+++ b/docs/generated/sparse.COO.rst
@@ -68,6 +68,7 @@ COO
       COO.to_scipy_sparse
       COO.tocsc
       COO.tocsr
+      COO.__array__
 
    .. rubric:: :doc:`Other operations <../user_manual/operations/other>`
    .. autosummary::

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -488,13 +488,30 @@ class COO(object):
         """
         return self.data.nbytes + self.coords.nbytes
 
-    @property
-    def __array_interface__(self):
-        return {
-            'shape': self.shape,
-            'data': self.todense(),
-            'typestr': self.dtype.str,
-        }
+    def __array__(self, dtype=None):
+        """
+        Helper function to speed up :code:`np.array(x)` conversion
+
+        Parameters
+        ----------
+        dtype: type
+            Datatype of dense array. The sparse array is cast before densification.
+
+        Returns
+        -------
+        array_like
+            The dense array.
+
+        See Also
+        --------
+        numpy.ndarray.__array__ : Numpy equivalent function.
+
+        """
+        if dtype is not None:
+            tmp = self.astype(dtype)
+        else:
+            tmp = self
+        return tmp.todense()
 
     def __len__(self):
         """

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -488,6 +488,14 @@ class COO(object):
         """
         return self.data.nbytes + self.coords.nbytes
 
+    @property
+    def __array_interface__(self):
+        return {
+            'shape': self.shape,
+            'data': self.todense(),
+            'typestr': self.dtype.str,
+        }
+
     def __len__(self):
         """
         Get "length" of array, which is by definition the size of the first

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -503,7 +503,9 @@ class COO(object):
         Returns
         -------
         NotImplemented
-            We do not implement this function, so this is what we return.
+            We do not implement this function, so we return
+            :obj:`NotImplemented`.
+
         See Also
         --------
         numpy.ndarray.__array__ : Numpy equivalent function.

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -490,27 +490,26 @@ class COO(object):
 
     def __array__(self, dtype=None):
         """
-        Helper function to speed up :code:`np.array(x)` conversion
+        Helper function that gets called during :code:`np.array(x)` conversion.
+        We deliberately return :code:`NotImplemented` to prevent accidental
+        densification.
 
         Parameters
         ----------
         dtype: type
-            Datatype of dense array. The sparse array is cast before densification.
+            Datatype requested by :code:`np.array(x)`. Has no effect on
+            output.
 
         Returns
         -------
-        array_like
-            The dense array.
-
+        NotImplemented
+            We do not implement this function, so this is what we return.
         See Also
         --------
         numpy.ndarray.__array__ : Numpy equivalent function.
 
         """
-        if dtype is not None:
-            return self.astype(dtype).maybe_densify()
-        else:
-            return self.maybe_densify()
+        return NotImplemented
 
     def __len__(self):
         """

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -2397,7 +2397,8 @@ class COO(object):
         >>> s.maybe_densify(allowed_nnz=5, allowed_fraction=0.25)
         Traceback (most recent call last):
             ...
-        NotImplementedError: Operation would require converting large sparse array to dense
+        NotImplementedError: Operation would require converting large sparse \
+array to dense. Use .todense() to force densification.
         """
         elements = np.prod(self.shape)
 

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -508,10 +508,9 @@ class COO(object):
 
         """
         if dtype is not None:
-            tmp = self.astype(dtype)
+            return self.astype(dtype).todense()
         else:
-            tmp = self
-        return tmp.todense()
+            return self.todense()
 
     def __len__(self):
         """

--- a/sparse/core.py
+++ b/sparse/core.py
@@ -508,9 +508,9 @@ class COO(object):
 
         """
         if dtype is not None:
-            return self.astype(dtype).todense()
+            return self.astype(dtype).maybe_densify()
         else:
-            return self.todense()
+            return self.maybe_densify()
 
     def __len__(self):
         """
@@ -2406,7 +2406,8 @@ class COO(object):
             return self.todense()
         else:
             raise NotImplementedError("Operation would require converting "
-                                      "large sparse array to dense")
+                                      "large sparse array to dense. Use "
+                                      ".todense() to force densification.")
 
 
 def tensordot(a, b, axes=2):

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -892,5 +892,11 @@ def test_len():
 def test_numpy_todense():
     # make sure that .astype(int) is never all zeros
     s = sparse.random((20, 30, 40)) * 100
-    assert np.allclose(np.array(s, dtype=int), s.astype(int).todense())
-    assert np.allclose(np.array(s), s.todense())
+    with pytest.raises(ValueError):
+        assert np.array(s)
+
+    with pytest.raises(ValueError):
+        assert np.array(s, dtype=int)
+
+    with pytest.raises(ValueError):
+        assert np.allclose(s, s.todense())

--- a/sparse/tests/test_core.py
+++ b/sparse/tests/test_core.py
@@ -887,3 +887,10 @@ def test_scalar_shape_construction():
 def test_len():
     s = sparse.random((20, 30, 40))
     assert len(s) == 20
+
+
+def test_numpy_todense():
+    # make sure that .astype(int) is never all zeros
+    s = sparse.random((20, 30, 40)) * 100
+    assert np.allclose(np.array(s, dtype=int), s.astype(int).todense())
+    assert np.allclose(np.array(s), s.todense())


### PR DESCRIPTION
Picking up from #68:

Implementing `len()` means that NumPy can create `np.ndarray`s from `COO` arrays using

    numpy.array(x)

But it's very very slow.

If I understand it correctly, `numpy.array(x)` looks for `buffer` and `__array_interface__` when creating an array from an object. If it doesn't find one it simply iterates over it (hence the slowness)

What if we implement `__array_interface__` that calls `self.todense()`?

```python
@property
def __array_interface__(self):
    return {
        'shape': self.shape,
        'data': self.todense(),
        'typestr': self.dtype.str,
    }

```

Before

```python
x = sparse.random((20, 30, 20))

%timeit numpy.array(x)
# 1.48 s ± 25.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
%timeit x.todense()
# 11.6 µs ± 40.3 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
numpy.allclose(x, x.todense)
# True
```

After

```python
%timeit numpy.array(x)
# 23 µs ± 392 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
numpy.allclose(x, x.todense)
# True
```

I can't explain where the 2x slowdown (11 vs 23 us) comes from though. The factor is also there for `x = sparse.random((20, 30, 40000))`: `78ms` vs `184ms`.

**But please be aware that I am phrasing this suggestion as a question!** I don't exactly know what NumPy does with the value returned from `__array_interface__`. Does it copy it? Does it share it? Are we leaking memory? Are we double-freeing it?