### PR TITLE
Tox for cross Python-version testing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(name='sparse',
       install_requires=list(open('requirements.txt').read().strip().split('\n')),
       extras_require={
           'tests': [
+              'tox',
               'pytest',
               'pytest-cov',
               'pytest-flake8',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27,py36
+[testenv]
+commands=
+    py.test {posargs}
+extras=
+    docs
+    tests


### PR DESCRIPTION
Note that the way Travis CI and `py.test` run their tests remain unchanged:

 - Travis CI runs multiple Python version tests in seprarate images
 - `py.test` works exactly as before

The only difference: Users can run `tox` on their local machines to test Python 2 and 3.